### PR TITLE
FIX bundler removing `React` when not explicitly used in code

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -703,6 +703,7 @@ dependencies = [
  "swc_ecma_loader",
  "swc_ecma_minifier",
  "swc_ecma_parser",
+ "swc_ecma_transforms_optimization",
  "swc_ecma_transforms_react",
  "swc_ecma_visit",
  "tauri",
@@ -3293,9 +3294,9 @@ dependencies = [
 
 [[package]]
 name = "swc_ecma_transforms_optimization"
-version = "0.198.17"
+version = "0.198.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86789174146707d78c086cee25868624bdfef924bb535ea3fc42f53fa426d4c0"
+checksum = "aa1a53995a9199fa11343506646d0cdce69e612a5dad47897169cf4fdf8b7fcb"
 dependencies = [
  "dashmap",
  "indexmap 2.2.6",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,6 +33,7 @@ swc_ecma_codegen = "0.148.10"
 swc_ecma_loader = { version = "0.45.21", features = ["node"] }
 swc_ecma_minifier = "0.192.19"
 swc_ecma_parser = "0.143.8"
+swc_ecma_transforms_optimization = "0.198.18"
 swc_ecma_transforms_react = "0.183.13"
 swc_ecma_visit = "0.98.6"
 

--- a/src-tauri/src/bundler.rs
+++ b/src-tauri/src/bundler.rs
@@ -170,6 +170,7 @@ impl Load for PathLoader {
                     err.into_diagnostic(&handler).emit();
                     panic!("FATAL: Failed to parse module");
                 });
+
         Ok(ModuleData { fm, module, helpers: Default::default() })
     }
 }


### PR DESCRIPTION
If one creates a simple widget like this:

```jsx
const React = window.__DESKULPT__.defaultDeps.React;

export default {
  render: () => <h1>Welcome!</h1>,
};
```

The bundler removes the `React` assignment because it performs tree shaking by default [[ref](https://rustdoc.swc.rs/src/swc_bundler/bundler/optimize.rs.html#22-33)] and `React` is not explicitly used in the code. However, we require to bring `React` into scope since the (classical) JSX transform  relies on it to transpile.

The workaround is to disabled tree-shaking in the bundler and fold with tree-shaking optimization later by ourselves. This way we can specify `React` as `top_retain` to avoid it from being removed by unused.

Later I will make sure to test this case when the test suite is set up.

/cc @CSCI-SHU-410-SE-Project/core-dev for review.