### PR TITLE
MAINT workaround pre-commit `/dev/tty` not found and fix escape error on Windows CMD

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -5,5 +5,8 @@
 # otherwise the fancy output of lint-staged will be disabled; see the husky issue
 # https://github.com/typicode/husky/issues/968
 
-exec 1> /dev/tty
+if [ -t 2 ]; then
+  exec >/dev/tty 2>&1
+fi
+
 npx lint-staged

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,19 +1,27 @@
 import { quote } from "shell-quote";
 
+const isWin = process.platform === "win32";
+
 export default {
   "**/*.{js,jsx,mjs,ts,tsx,mts}": (filenames) => {
-    const fileArgs = quote(filenames);
+    const fileArgs = escape(filenames);
     return [
       `prettier --write ${fileArgs}`,
       `eslint --max-warnings=0 --fix ${fileArgs}`,
     ];
   },
   "**/*.{json,json5,md,html,css,scss,yml,yaml}": (filenames) => {
-    const fileArgs = quote(filenames);
+    const fileArgs = escape(filenames);
     return [`prettier --write ${fileArgs}`];
   },
   "**/*.rs": (filenames) => {
-    const fileArgs = quote(filenames);
+    const fileArgs = escape(filenames);
     return [`rustfmt -- ${fileArgs}`];
   },
 };
+
+function escape(filenames) {
+  return filenames
+    .map((filename) => (isWin ? `"${filename}"` : quote([filename])))
+    .join(" ");
+}


### PR DESCRIPTION
This PR does the following:

- Redirect only when file descriptor 2 (stderr) is connected to the terminal. This workaround is suggested in https://github.com/typicode/husky/issues/968#issuecomment-1184296264. I've tested with the VS Code "commit" button; it raises previously and works now.
- Better escape mechanism in `lint-staged`. This part refers to [the configuration of `next.js`](https://github.com/vercel/next.js/blob/canary/lint-staged.config.js).

@Xinyu-Li-123 Can you please confirm if these solve your issue?