### PR TITLE
FIX bundler parsing error should not panic

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -128,17 +128,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "auto_impl"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -687,10 +676,10 @@ name = "deskulpt"
 version = "0.0.0"
 dependencies = [
  "anyhow",
- "normpath 1.2.0",
+ "normpath",
  "parameterized",
  "parking_lot",
- "path-clean 1.0.1",
+ "path-clean",
  "pretty_assertions",
  "serde",
  "serde-error",
@@ -1340,15 +1329,6 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
@@ -1815,15 +1795,6 @@ checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
 name = "normpath"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a9da8c9922c35a1033d76f7272dfc2e7ee20392083d75aeea6ced23c6266578"
-dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "normpath"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5831952a9476f2fed74b77d74182fa5ddc4d21c72ec45a333b250e3ed0272804"
@@ -1883,7 +1854,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.9",
+ "hermit-abi",
  "libc",
 ]
 
@@ -2041,12 +2012,6 @@ dependencies = [
  "smallvec",
  "windows-targets 0.48.5",
 ]
-
-[[package]]
-name = "path-clean"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecba01bf2678719532c5e3059e0b5f0811273d94b397088b82e3bd0a78c78fdd"
 
 [[package]]
 name = "path-clean"
@@ -3088,7 +3053,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89598a0dfe7311750e6fad8464cafcec8ee010c649c2e04531b25e32362fdec7"
 dependencies = [
  "ast_node",
- "atty",
  "better_scoped_tls",
  "cfg-if",
  "either",
@@ -3102,7 +3066,6 @@ dependencies = [
  "swc_atoms",
  "swc_eq_ignore_macros",
  "swc_visit",
- "termcolor",
  "tracing",
  "unicode-width",
  "url",
@@ -3191,13 +3154,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d32a45baefc2e53ad553f30df5536fbd2818b5e1adc84c801a0e88e09a0a7e9"
 dependencies = [
  "anyhow",
- "dashmap",
- "normpath 0.2.0",
- "once_cell",
- "path-clean 0.1.0",
  "pathdiff",
  "serde",
- "serde_json",
  "swc_atoms",
  "swc_common",
  "tracing",
@@ -3808,15 +3766,6 @@ dependencies = [
  "futf",
  "mac",
  "utf-8",
-]
-
-[[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -708,6 +708,7 @@ dependencies = [
  "swc_ecma_visit",
  "tauri",
  "tauri-build",
+ "tempfile",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,10 +28,10 @@ tempfile = "3.10.1"
 parking_lot = "0.12.1"  # Required by swc_ecma_loader
 swc_atoms = "0.6.5"
 swc_bundler = "0.225.13"
-swc_common = { version = "0.33.19", features = ["tty-emitter"] }
+swc_common = "0.33.19"
 swc_ecma_ast = "0.112.5"
 swc_ecma_codegen = "0.148.10"
-swc_ecma_loader = { version = "0.45.21", features = ["node"] }
+swc_ecma_loader = "0.45.21"
 swc_ecma_minifier = "0.192.19"
 swc_ecma_parser = "0.143.8"
 swc_ecma_transforms_optimization = "0.198.18"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -22,6 +22,7 @@ path-clean = "1.0.1"
 serde = { version = "1.0.197", features = ["derive"] }
 serde-error = "0.1.2"
 serde_json = "1.0.1"
+tempfile = "3.10.1"
 
 # SWC crates and related
 parking_lot = "0.12.1"  # Required by swc_ecma_loader

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -25,7 +25,7 @@ pub(crate) enum CommandOut<T> {
 
 impl<T> CommandOut<T> {
     pub(crate) fn fail<E: Debug>(err: E) -> Self {
-        CommandOut::Failure(format!("{:#?}", err))
+        CommandOut::Failure(format!("{:?}", err))
     }
 }
 


### PR DESCRIPTION
Fixes #9.

This PR attempts to emit the parsing error in a formatted way instead of panicking (which is clearly wrong). The rendered error message of the reproducer in #9 should now look like this (no color, but formatted):

![image](https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/assets/108576690/175917f6-6b8f-4ec3-a78a-70bf3ce25ae3)

I've also added a corresponding widget to [`test-widgets`](https://github.com/CSCI-SHU-410-SE-Project/test-widgets/tree/main/err-bundler-parse).

/cc @Xinyu-Li-123 Can you give a review and confirm if this works?