### PR TITLE
ENH show manager window/close app using system tray

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1762,10 +1762,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baff4b617f7df3d896f97fe922b64817f6cd9a756bb81d40f8883f2f66dcb401"
 
 [[package]]
+name = "libappindicator"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2d3cb96d092b4824cb306c9e544c856a4cb6210c1081945187f7f1924b47e8"
+dependencies = [
+ "glib",
+ "gtk",
+ "gtk-sys",
+ "libappindicator-sys",
+ "log",
+]
+
+[[package]]
+name = "libappindicator-sys"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1b3b6681973cea8cc3bce7391e6d7d5502720b80a581c9a95c9cbaf592826aa"
+dependencies = [
+ "gtk-sys",
+ "libloading",
+ "once_cell",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
+
+[[package]]
+name = "libloading"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
+dependencies = [
+ "cfg-if",
+ "winapi",
+]
 
 [[package]]
 name = "libredox"
@@ -3680,6 +3714,7 @@ dependencies = [
  "core-foundation",
  "core-graphics",
  "crossbeam-channel",
+ "dirs-next",
  "dispatch",
  "gdk",
  "gdk-pixbuf",
@@ -3694,6 +3729,7 @@ dependencies = [
  "instant",
  "jni",
  "lazy_static",
+ "libappindicator",
  "libc",
  "log",
  "ndk",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -14,7 +14,7 @@ pretty_assertions = "1.4.0"
 rstest = "0.19.0"
 
 [dependencies]
-tauri = { version = "1.6.1", features = ["shell-open", "config-json5", "test"] }
+tauri = { version = "1.6.1", features = ["shell-open", "config-json5", "test", "system-tray"] }
 
 # Utilities
 anyhow = "1.0.80"

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -7,6 +7,7 @@ use tauri::{api, generate_context, generate_handler, Builder};
 mod bundler;
 mod commands;
 mod config;
+mod setup;
 mod states;
 mod widget_api;
 
@@ -25,15 +26,21 @@ fn main() {
     }
 
     Builder::default()
+        // Additional application setup
+        .system_tray(setup::get_system_tray())
+        .on_system_tray_event(setup::listen_to_system_tray)
+        .on_window_event(setup::listen_to_windows)
+        // Initialize state management
         .manage(states::WidgetBaseDirectoryState(widget_base_dir))
         .manage(states::WidgetCollectionState::default())
+        // Register internal command handlers
         .invoke_handler(generate_handler![
             commands::bundle_widget,
             commands::open_widget_base,
             commands::refresh_widget_collection,
         ])
-        // Initialize widget apis
+        // Register widget API plugins
         .plugin(widget_api::fs::init())
         .run(context)
-        .expect("FATAL");
+        .expect("Error running the Deskulpt application");
 }

--- a/src-tauri/src/setup.rs
+++ b/src-tauri/src/setup.rs
@@ -1,0 +1,80 @@
+//! The module configures the system tray of Deskulpt.
+
+use tauri::{
+    App, AppHandle, CustomMenuItem, GlobalWindowEvent, Manager, SystemTray,
+    SystemTrayEvent, SystemTrayMenu, WindowBuilder, WindowEvent,
+};
+
+/// Listen to global window events.
+///
+/// This is to be initialized with `builder.on_window_event(listen_to_windows)` on the
+/// application builder instance. It does the following:
+///
+/// - Prevent the manager window from closing when the close button is clicked.
+pub(crate) fn listen_to_windows(e: GlobalWindowEvent) {
+    match e.event() {
+        WindowEvent::CloseRequested { api, .. } => {
+            let window = e.window();
+            if window.label() == "manager" {
+                api.prevent_close();
+                window.hide().unwrap();
+            }
+        },
+        _ => {},
+    }
+}
+
+/// Get the system tray of Deskulpt.
+///
+/// This is to be initialized with `builder.system_tray(get_system_tray())` on the
+/// application builder instance.
+pub(crate) fn get_system_tray() -> SystemTray {
+    let tray_menu = SystemTrayMenu::new()
+        .add_item(CustomMenuItem::new("manage", "Manage"))
+        .add_item(CustomMenuItem::new("exit", "Exit"));
+    return SystemTray::new().with_menu(tray_menu);
+}
+
+/// Listen to system tray events.
+///
+/// This is to be initialized with `builder.on_system_tray_event(listen_to_system_tray)`
+/// on the application builder instance. It does the following:
+///
+/// - When left-clicking the tray icon or clicking the "manage" menu item, show the
+///   manager window. Note that left-clicking is unsupported on Linux, so the "manage"
+///   menu item is present as a workaround.
+/// - When clicking the "exit" menu item, exit the application (with cleanup).
+pub(crate) fn listen_to_system_tray(
+    app_handle: &AppHandle,
+    event: SystemTrayEvent,
+) -> () {
+    match event {
+        SystemTrayEvent::MenuItemClick { id, .. } => match id.as_str() {
+            "manage" => show_manager_window(app_handle),
+            "exit" => app_handle.exit(0),
+            _ => {},
+        },
+        SystemTrayEvent::LeftClick { .. } => {
+            show_manager_window(app_handle);
+        },
+        _ => {},
+    }
+}
+
+/// Attempt to show the manager window.
+///
+/// If the manager window does not exist, create the window. If the window exists but
+/// fails to show, consume the error and do nothing.
+fn show_manager_window(app_handle: &AppHandle) -> () {
+    if let Some(manager) = app_handle.get_window("manager").or_else(|| {
+        // Failed to get the manager window; we create a new one from the existing
+        // configuration instead; note that the manager window is the second item in
+        // the window list in `tauri.conf.json5`
+        let config = app_handle.config().tauri.windows.get(1).unwrap().clone();
+        // Discard any error if the window fails to be built, because this likely means
+        // that the manager window is still there
+        WindowBuilder::from_config(app_handle, config.clone()).build().ok()
+    }) {
+        let _ = manager.show(); // Discard any error
+    }
+}

--- a/src-tauri/src/setup.rs
+++ b/src-tauri/src/setup.rs
@@ -1,8 +1,8 @@
 //! The module configures the system tray of Deskulpt.
 
 use tauri::{
-    App, AppHandle, CustomMenuItem, GlobalWindowEvent, Manager, SystemTray,
-    SystemTrayEvent, SystemTrayMenu, WindowBuilder, WindowEvent,
+    AppHandle, CustomMenuItem, GlobalWindowEvent, Manager, SystemTray, SystemTrayEvent,
+    SystemTrayMenu, WindowBuilder, WindowEvent,
 };
 
 /// Listen to global window events.
@@ -12,15 +12,12 @@ use tauri::{
 ///
 /// - Prevent the manager window from closing when the close button is clicked.
 pub(crate) fn listen_to_windows(e: GlobalWindowEvent) {
-    match e.event() {
-        WindowEvent::CloseRequested { api, .. } => {
-            let window = e.window();
-            if window.label() == "manager" {
-                api.prevent_close();
-                window.hide().unwrap();
-            }
-        },
-        _ => {},
+    if let WindowEvent::CloseRequested { api, .. } = e.event() {
+        let window = e.window();
+        if window.label() == "manager" {
+            api.prevent_close();
+            window.hide().unwrap();
+        }
     }
 }
 
@@ -32,7 +29,7 @@ pub(crate) fn get_system_tray() -> SystemTray {
     let tray_menu = SystemTrayMenu::new()
         .add_item(CustomMenuItem::new("manage", "Manage"))
         .add_item(CustomMenuItem::new("exit", "Exit"));
-    return SystemTray::new().with_menu(tray_menu);
+    SystemTray::new().with_menu(tray_menu)
 }
 
 /// Listen to system tray events.
@@ -44,10 +41,7 @@ pub(crate) fn get_system_tray() -> SystemTray {
 ///   manager window. Note that left-clicking is unsupported on Linux, so the "manage"
 ///   menu item is present as a workaround.
 /// - When clicking the "exit" menu item, exit the application (with cleanup).
-pub(crate) fn listen_to_system_tray(
-    app_handle: &AppHandle,
-    event: SystemTrayEvent,
-) -> () {
+pub(crate) fn listen_to_system_tray(app_handle: &AppHandle, event: SystemTrayEvent) {
     match event {
         SystemTrayEvent::MenuItemClick { id, .. } => match id.as_str() {
             "manage" => show_manager_window(app_handle),
@@ -65,7 +59,7 @@ pub(crate) fn listen_to_system_tray(
 ///
 /// If the manager window does not exist, create the window. If the window exists but
 /// fails to show, consume the error and do nothing.
-fn show_manager_window(app_handle: &AppHandle) -> () {
+fn show_manager_window(app_handle: &AppHandle) {
     if let Some(manager) = app_handle.get_window("manager").or_else(|| {
         // Failed to get the manager window; we create a new one from the existing
         // configuration instead; note that the manager window is the second item in

--- a/src-tauri/tauri.conf.json5
+++ b/src-tauri/tauri.conf.json5
@@ -25,17 +25,22 @@
         label: "canvas",
         title: "Deskulpt Canvas",
         url: "views/canvas.html",
-        width: 800,
-        height: 600,
       },
       {
         label: "manager",
         title: "Deskulpt Manager",
         url: "views/index.html",
-        width: 800,
-        height: 600,
+        width: 750,
+        height: 500,
+        center: true,
+        resizable: false,
+        visible: false, // Hide on launch, show with tray icon
       },
     ],
+    systemTray: {
+      iconPath: "icons/icon.png",
+      iconAsTemplate: true,
+    },
     security: {
       csp: null,
     },


### PR DESCRIPTION
This PR adds a system tray for the application. The system tray currently has two functionalities:

- Left click or click on "Manage": open the manager window.
- Click on "Exit": quit the application.

Other changes include:

- The manager window starts invisible. Use the tray icon to show it.
- Closing the manager window does not really close it. It hides it (setting to invisible) instead.
- The manager window is no longer resizable.