### PR TITLE
FIX `ReactDOM.findDOMNode()` is deprecated caused by `Draggable`

### DIFF
--- a/src/components/WidgetContainer/index.tsx
+++ b/src/components/WidgetContainer/index.tsx
@@ -16,12 +16,14 @@ export default function WidgetContainer(props: {
   id: string;
   inner: React.ReactElement;
 }) {
+  const containerRef = React.useRef(null);
   const { id, inner } = props;
 
   return (
     <React.StrictMode>
-      <Draggable>
+      <Draggable nodeRef={containerRef}>
         <Box
+          ref={containerRef}
           sx={{
             px: 2,
             py: 1,


### PR DESCRIPTION
Since we wrap in `React.StrictMode` in dev mode for debugging, `Draggable` causes a deprecation warning as described in the title with the latest version of `React` that we are using. The PR implemented the fix mentioned in the [changelog of `Draggable`](https://github.com/react-grid-layout/react-draggable/blob/master/CHANGELOG.md#440-may-12-2020).