### PR TITLE
MAINT better build and release workflows

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -77,7 +77,7 @@ jobs:
       - name: Get short commit SHA
         id: short-sha
         run: |
-          shortsha=$(echo ${{ github.sha }} | cut -c 1-7)
+          shortsha=$(echo ${{ github.event.pull_request.head.sha }} | cut -c 1-7)
           echo "sha=$shortsha" >> $GITHUB_OUTPUT
 
       - name: Find comment
@@ -95,19 +95,12 @@ jobs:
         with:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
-          body: |-
+          body: |
             ## ✔️ Deskulpt Built Successfully!
 
-            Deskulpt binaries have been built successfully on all supported platforms.
-            Your pull request is in excellent shape! ☀️
+            Deskulpt binaries have been built successfully on all supported platforms. Your pull request is in excellent shape! ☀️
 
-            <sub>
-              Workflow file: `.github/workflows/build.yaml`.
-              Generated for commit:
-              [`${{ steps.short-sha.outputs.sha }}`](https://github.com/${{ github.repository }}/pull/${{ github.event.number }}/commits/${{ github.sha }}).
-              Link to the built binaries:
-              [here](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
-            </sub>
+            <sub> Workflow file: `.github/workflows/build.yaml`. Generated for commit: [`${{ steps.short-sha.outputs.sha }}`](https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}/commits/${{ github.event.pull_request.head.sha }}). Link to the built binaries: [here](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) </sub>
           edit-mode: replace
 
   comment-failure:
@@ -119,7 +112,7 @@ jobs:
       - name: Get short commit SHA
         id: short-sha
         run: |
-          shortsha=$(echo ${{ github.sha }} | cut -c 1-7)
+          shortsha=$(echo ${{ github.event.pull_request.head.sha }} | cut -c 1-7)
           echo "sha=$shortsha" >> $GITHUB_OUTPUT
 
       - name: Find comment
@@ -140,14 +133,7 @@ jobs:
           body: |-
             ## ❌ Failed to Build Deskulpt
 
-            There seems to be some issues with the build process for certain platforms.
-            Please check the logs to see what went wrong and fix the issues accordingly.
+            There seems to be some issues with the build process for certain platforms. Please check the logs to see what went wrong and fix the issues accordingly.
 
-            <sub>
-              Workflow file: `.github/workflows/build.yaml`.
-              Generated for commit:
-              [`${{ steps.short-sha.outputs.sha }}`](https://github.com/${{ github.repository }}/pull/${{ github.event.number }}/commits/${{ github.sha }}).
-              Link to the failing workflow run:
-              [here](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
-            </sub>
+            <sub> Workflow file: `.github/workflows/build.yaml`. Generated for commit: [`${{ steps.short-sha.outputs.sha }}`](https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}/commits/${{ github.event.pull_request.head.sha }}). Link to the failing workflow run: [here](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) </sub>
           edit-mode: replace

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,6 +24,9 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
+      - name: Fail the job
+        run: exit 1
+
       - name: Checkout repository
         uses: actions/checkout@v4
 
@@ -79,12 +82,24 @@ jobs:
           comment-author: "github-actions[bot]"
           body-includes: Check the built Deskulpt binaries at
 
-      - name: Create or update comment
+      - name: Post success comment
+        if: always() && needs.build.result == 'success'
         uses: peter-evans/create-or-update-comment@v4
         with:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            Check the built Deskulpt binaries at:
-            ${{ steps.upload-artifacts.outputs.artifact_url }}
+            Check the built Deskulpt binaries
+            [here](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).
+          edit-mode: replace
+
+      - name: Post failure comment
+        if: always() && needs.build.result != 'success'
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            Failed to build Deskulpt binaries. Check the workflow run
+            [here](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).
           edit-mode: replace

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,7 +60,6 @@ jobs:
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
-        if: matrix.platform == 'ubuntu-latest'
         with:
           name: binaries-${{ matrix.platform }}
           path: "${{ join(fromJSON(steps.build-deskulpt.outputs.artifactPaths), '\n') }}"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -60,6 +60,8 @@ jobs:
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4
+        if: matrix.platform == 'ubuntu-latest'
         with:
           name: Deskulpt
-          path: ${{ join(fromJSON(steps.build-deskulpt.outputs.artifactPaths), '\n') }}
+          # path: ${{ join(fromJSON(steps.build-deskulpt.outputs.artifactPaths), '\n') }}
+          path: /home/runner/work/Deskulpt/Deskulpt/src-tauri/target/release/bundle/**/*

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -98,9 +98,9 @@ jobs:
           body: |
             ## ✔️ Deskulpt Built Successfully!
 
-            Deskulpt binaries have been built successfully on all supported platforms. Your pull request is in excellent shape! ☀️
+            Deskulpt binaries have been built successfully on all supported platforms. Your pull request is in excellent shape! You may check the built Deskulpt binaries [here](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) and download them to test locally.
 
-            <sub> Workflow file: `.github/workflows/build.yaml`. Generated for commit: [`${{ steps.short-sha.outputs.sha }}`](https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}/commits/${{ github.event.pull_request.head.sha }}). Link to the built binaries: [here](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) </sub>
+            <sub> Workflow file: `.github/workflows/build.yaml`. Generated for commit: [`${{ steps.short-sha.outputs.sha }}`](https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}/commits/${{ github.event.pull_request.head.sha }}). </sub>
           edit-mode: replace
 
   comment-failure:
@@ -133,7 +133,7 @@ jobs:
           body: |-
             ## ❌ Failed to Build Deskulpt
 
-            There seems to be some issues with the build process for certain platforms. Please check the logs to see what went wrong and fix the issues accordingly.
+            There seems to be some issues with the build process for certain platforms. Please check the logs in the [failing workflow run](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) for more details and fix the issues accordingly.
 
-            <sub> Workflow file: `.github/workflows/build.yaml`. Generated for commit: [`${{ steps.short-sha.outputs.sha }}`](https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}/commits/${{ github.event.pull_request.head.sha }}). Link to the failing workflow run: [here](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) </sub>
+            <sub> Workflow file: `.github/workflows/build.yaml`. Generated for commit: [`${{ steps.short-sha.outputs.sha }}`](https://github.com/${{ github.repository }}/pull/${{ github.event.pull_request.number }}/commits/${{ github.event.pull_request.head.sha }}). </sub>
           edit-mode: replace

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -76,7 +76,9 @@ jobs:
     steps:
       - name: Get short commit SHA
         id: short-sha
-        run: echo "sha=${{ github.sha }}" | cut -c 5-11 >> $GITHUB_OUTPUT
+        run: |
+          shortsha=$(echo ${{ github.sha }} | cut -c 1-7)
+          echo "sha=$shortsha" >> $GITHUB_OUTPUT
 
       - name: Find comment
         id: find-comment
@@ -93,7 +95,7 @@ jobs:
         with:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
-          body: |
+          body: |-
             ## ✔️ Deskulpt Built Successfully!
 
             Deskulpt binaries have been built successfully on all supported platforms.
@@ -116,7 +118,9 @@ jobs:
     steps:
       - name: Get short commit SHA
         id: short-sha
-        run: echo "sha=${{ github.sha }}" | cut -c 5-11 >> $GITHUB_OUTPUT
+        run: |
+          shortsha=$(echo ${{ github.sha }} | cut -c 1-7)
+          echo "sha=$shortsha" >> $GITHUB_OUTPUT
 
       - name: Find comment
         id: find-comment

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -74,6 +74,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Get short commit SHA
+        id: short-sha
+        run: echo ${{ github.sha }} | cut -c 1-7 >> $GITHUB_OUTPUT
+
       - name: Find comment
         id: find-comment
         uses: peter-evans/find-comment@v3
@@ -95,8 +99,9 @@ jobs:
             Your pull request is in excellent shape! ☀️
 
             <sub>
+              Workflow file: `.github/workflows/build.yaml`.
               Generated for commit:
-              [${{ github.sha.slice(0, 7) }}](https://github.com/${{ github.repository }}/pull/${{ github.event.number }}/commits/${{ github.sha }}).
+              [`${{ steps.short-sha.outputs }}`](https://github.com/${{ github.repository }}/pull/${{ github.event.number }}/commits/${{ github.sha }}).
               Link to the built binaries:
               [here](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
             </sub>
@@ -115,8 +120,9 @@ jobs:
             Please check the logs to see what went wrong and fix the issues accordingly.
 
             <sub>
+              Workflow file: `.github/workflows/build.yaml`.
               Generated for commit:
-              [${{ github.sha.slice(0, 7) }}](https://github.com/${{ github.repository }}/pull/${{ github.event.number }}/commits/${{ github.sha }}).
+              [`${{ steps.short-sha.outputs }}`](https://github.com/${{ github.repository }}/pull/${{ github.event.number }}/commits/${{ github.sha }}).
               Link to the failing workflow run:
               [here](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
             </sub>

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,6 +53,13 @@ jobs:
       # Without specifying `tagName` and `releaseId`, tauri-action will only build the
       # application without trying to upload any assets
       - name: Build Deskulpt
+        id: build-deskulpt
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: Deskulpt
+          path: ${{ steps.build-deskulpt.outputs.artifactPaths }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -62,4 +62,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Deskulpt
-          path: ${{ steps.build-deskulpt.outputs.artifactPaths }}
+          path: ${{ join(fromJSON(steps.build-deskulpt.outputs.artifactPaths), "\n") }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -76,7 +76,7 @@ jobs:
     steps:
       - name: Get short commit SHA
         id: short-sha
-        run: echo ${{ github.sha }} | cut -c 1-7 >> $GITHUB_OUTPUT
+        run: echo "sha=${{ github.sha }}" | cut -c 5-11 >> $GITHUB_OUTPUT
 
       - name: Find comment
         id: find-comment
@@ -85,7 +85,7 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: "github-actions[bot]"
           body-includes: |
-            Workflow file: `.github/workflows/build.yaml`.
+            .github/workflows/build.yaml
 
       - name: Post success comment
         if: "always() && (needs.build.result == 'success')"
@@ -102,7 +102,7 @@ jobs:
             <sub>
               Workflow file: `.github/workflows/build.yaml`.
               Generated for commit:
-              [`${{ steps.short-sha.outputs }}`](https://github.com/${{ github.repository }}/pull/${{ github.event.number }}/commits/${{ github.sha }}).
+              [`${{ steps.short-sha.outputs.sha }}`](https://github.com/${{ github.repository }}/pull/${{ github.event.number }}/commits/${{ github.sha }}).
               Link to the built binaries:
               [here](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
             </sub>
@@ -116,7 +116,7 @@ jobs:
     steps:
       - name: Get short commit SHA
         id: short-sha
-        run: echo ${{ github.sha }} | cut -c 1-7 >> $GITHUB_OUTPUT
+        run: echo "sha=${{ github.sha }}" | cut -c 5-11 >> $GITHUB_OUTPUT
 
       - name: Find comment
         id: find-comment
@@ -125,7 +125,7 @@ jobs:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: "github-actions[bot]"
           body-includes: |
-            Workflow file: `.github/workflows/build.yaml`.
+            .github/workflows/build.yaml
 
       - name: Post failure comment
         if: "always() && (needs.build.result != 'success')"
@@ -133,8 +133,8 @@ jobs:
         with:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
-          body: |
-            ## ❌ Deskulpt Build Issues
+          body: |-
+            ## ❌ Failed to Build Deskulpt
 
             There seems to be some issues with the build process for certain platforms.
             Please check the logs to see what went wrong and fix the issues accordingly.
@@ -142,7 +142,7 @@ jobs:
             <sub>
               Workflow file: `.github/workflows/build.yaml`.
               Generated for commit:
-              [`${{ steps.short-sha.outputs }}`](https://github.com/${{ github.repository }}/pull/${{ github.event.number }}/commits/${{ github.sha }}).
+              [`${{ steps.short-sha.outputs.sha }}`](https://github.com/${{ github.repository }}/pull/${{ github.event.number }}/commits/${{ github.sha }}).
               Link to the failing workflow run:
               [here](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
             </sub>

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -83,23 +83,41 @@ jobs:
           body-includes: Check the built Deskulpt binaries at
 
       - name: Post success comment
-        if: always() && needs.build.result == 'success'
+        if: "always() && (needs.build.result == 'success')"
         uses: peter-evans/create-or-update-comment@v4
         with:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            Check the built Deskulpt binaries
-            [here](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).
+            ## ✔️ Deskulpt Built Successfully!
+
+            Deskulpt binaries have been built successfully on all supported platforms.
+            Your pull request is in excellent shape! ☀️
+
+            <sub>
+              Generated for commit:
+              [${{ github.sha.slice(0, 7) }}](https://github.com/${{ github.repository }}/pull/${{ github.event.number }}/commits/${{ github.sha }}).
+              Link to the built binaries:
+              [here](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
+            </sub>
           edit-mode: replace
 
       - name: Post failure comment
-        if: always() && needs.build.result != 'success'
+        if: "always() && (needs.build.result != 'success')"
         uses: peter-evans/create-or-update-comment@v4
         with:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            Failed to build Deskulpt binaries. Check the workflow run
-            [here](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}).
+            ## ❌ Deskulpt Build Issues
+
+            There seems to be some issues with the build process for certain platforms.
+            Please check the logs to see what went wrong and fix the issues accordingly.
+
+            <sub>
+              Generated for commit:
+              [${{ github.sha.slice(0, 7) }}](https://github.com/${{ github.repository }}/pull/${{ github.event.number }}/commits/${{ github.sha }}).
+              Link to the failing workflow run:
+              [here](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
+            </sub>
           edit-mode: replace

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -68,9 +68,9 @@ jobs:
           name: binaries-${{ matrix.platform }}
           path: "${{ join(fromJSON(steps.build-deskulpt.outputs.artifactPaths), '\n') }}"
 
-  comment:
+  comment-success:
     needs: build
-    if: github.event_name == 'pull_request' # Comment only on pull requests
+    if: always() && needs.build.result == 'success' && github.event_name == 'pull_request'
     runs-on: ubuntu-latest
 
     steps:
@@ -84,7 +84,8 @@ jobs:
         with:
           issue-number: ${{ github.event.pull_request.number }}
           comment-author: "github-actions[bot]"
-          body-includes: Check the built Deskulpt binaries at
+          body-includes: |
+            Workflow file: `.github/workflows/build.yaml`.
 
       - name: Post success comment
         if: "always() && (needs.build.result == 'success')"
@@ -106,6 +107,25 @@ jobs:
               [here](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})
             </sub>
           edit-mode: replace
+
+  comment-failure:
+    needs: build
+    if: always() && needs.build.result != 'success' && github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get short commit SHA
+        id: short-sha
+        run: echo ${{ github.sha }} | cut -c 1-7 >> $GITHUB_OUTPUT
+
+      - name: Find comment
+        id: find-comment
+        uses: peter-evans/find-comment@v3
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: "github-actions[bot]"
+          body-includes: |
+            Workflow file: `.github/workflows/build.yaml`.
 
       - name: Post failure comment
         if: "always() && (needs.build.result != 'success')"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -62,4 +62,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Deskulpt
-          path: ${{ join(fromJSON(steps.build-deskulpt.outputs.artifactPaths), "\n") }}
+          path: ${{ join(fromJSON(steps.build-deskulpt.outputs.artifactPaths), '\n') }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -59,7 +59,32 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload build artifacts
+        id: upload-artifacts
         uses: actions/upload-artifact@v4
         with:
           name: binaries-${{ matrix.platform }}
           path: "${{ join(fromJSON(steps.build-deskulpt.outputs.artifactPaths), '\n') }}"
+
+  comment:
+    needs: build
+    if: github.event_name == 'pull_request' # Comment only on pull requests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Find comment
+        id: find-comment
+        uses: peter-evans/find-comment@v3
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: "github-actions[bot]"
+          body-includes: Check the built Deskulpt binaries at
+
+      - name: Create or update comment
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            Check the built Deskulpt binaries at:
+            ${{ steps.upload-artifacts.outputs.artifact_url }}
+          edit-mode: replace

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -62,6 +62,5 @@ jobs:
         uses: actions/upload-artifact@v4
         if: matrix.platform == 'ubuntu-latest'
         with:
-          name: Deskulpt
-          # path: ${{ join(fromJSON(steps.build-deskulpt.outputs.artifactPaths), '\n') }}
-          path: /home/runner/work/Deskulpt/Deskulpt/src-tauri/target/release/bundle/**/*
+          name: binaries-${{ matrix.platform }}
+          path: "${{ join(fromJSON(steps.build-deskulpt.outputs.artifactPaths), '\n') }}"

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,9 +24,6 @@ jobs:
     runs-on: ${{ matrix.platform }}
 
     steps:
-      - name: Fail the job
-        run: exit 1
-
       - name: Checkout repository
         uses: actions/checkout@v4
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,9 @@
-name: "Release"
+name: Release Deskulpt
 
 on:
   push:
-    tags:
-      - "v*"
+    branches:
+      - release
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,64 @@
+name: "Release"
+
+on:
+  push:
+    branches:
+      - release
+
+jobs:
+  publish-deskulpt:
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: macos-latest # Arm-based macOS (M1 and above)
+            args: --target aarch64-apple-darwin
+          - platform: macos-latest # Intel-based macOS
+            args: --target x86_64-apple-darwin
+          - platform: ubuntu-latest
+            args: ""
+          - platform: windows-latest
+            args: ""
+    runs-on: ${{ matrix.platform }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install dependencies (Ubuntu only)
+        if: matrix.platform == 'ubuntu-latest'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev
+
+      - name: Rust setup
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
+
+      - name: Rust cache
+        uses: swatinem/rust-cache@v2
+        with:
+          workspaces: ./src-tauri -> target
+
+      - name: Node setup and cache
+        uses: actions/setup-node@v4
+        with:
+          node-version: lts/*
+          cache: npm
+
+      - name: Install frontend dependencies
+        run: npm install
+
+      - uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tagName: v__VERSION__
+          releaseName: "Deskulpt v__VERSION__"
+          releaseBody: "See the assets to download this version and install."
+          releaseDraft: true
+          prerelease: false
+          args: ${{ matrix.args }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -2,8 +2,9 @@ name: "Release"
 
 on:
   push:
-    branches:
-      - release
+    tags:
+      - "v*"
+  workflow_dispatch:
 
 jobs:
   publish-deskulpt:
@@ -58,7 +59,8 @@ jobs:
         with:
           tagName: v__VERSION__
           releaseName: "Deskulpt v__VERSION__"
-          releaseBody: "See the assets to download this version and install."
+          releaseBody: |
+            See the assets to download this version of Deskulpt and install.
           releaseDraft: true
           prerelease: false
           args: ${{ matrix.args }}

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,8 +1,6 @@
 [package]
 name = "deskulpt"
 version = "0.0.0"
-description = "Deskulpt (Desktop + Sculpt, pronounced /'deskʌlpt/), a cross-platform desktop customization tool."
-authors = ["Xinyu Li", "Yao Xiao", "Yuchen Zhou", "Frank Zhu"]
 edition = "2021"
 
 [build-dependencies]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Deskulpt",
-  "version": "0.0.0",
+  "version": "0.0.1-alpha.1",
   "identifier": "com.tauri.deskulpt",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "productName": "Deskulpt",
-  "version": "0.0.1-alpha.1",
+  "version": "0.0.1",
   "identifier": "com.tauri.deskulpt",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Artifact upload and automatic comment

This PR uploads the built binaries of the supported platforms to Github Actions, and automatically generate a comment to either redirect to the location of those artifacts (on success), or to link to the failed workflow (on failure). See https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/pull/58#issuecomment-2110390520 as an example. In particular,

| Success | Failure |
| ------- | ------- |
| ![aae20100a7305e5a55101a13721dfce](https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/assets/108576690/8e8785ee-be1a-41b1-b903-b3e5f01a5b1c) | ![581228b1f548282226683a00e0bc9f5](https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/assets/108576690/45f0c633-d848-46c7-a907-ea8af55663a2) |

## Release workflow

I'm also not familiar with it yet; I simply referred to other projects (e.g. [WindowPet](https://github.com/SeakMengs/WindowPet/blob/main/.github/workflows/release.yml)) and `tauri-action` examples. I don't know if it can ever be tested in a PR.