### PR TITLE
FIX error in the exported render function breaks react render loop

### DIFF
--- a/src/canvas/hooks/useRenderWidgetListener.tsx
+++ b/src/canvas/hooks/useRenderWidgetListener.tsx
@@ -127,11 +127,15 @@ export default function useRenderWidgetListener(
         return;
       }
 
-      // We have validated the module so we can call `render` safely
+      // We have validated the module so we can call `render` safely; there could be
+      // error within `render` so it needs to called in advance, otherwise things will
+      // get broken in the state setter, causing the error to be uncaught and also
+      // affecting other widget displays
+      const widgetDisplay = module.default.render();
       setCanvasWidgetStates((prev) => ({
         ...prev,
         [widgetId]: {
-          display: module.default.render(),
+          display: widgetDisplay,
           width: module.default.width,
           height: module.default.height,
           moduleBlobUrl,


### PR DESCRIPTION
Try doing some nonsense in the exported `render` function, e.g.

```js
export default {
  render: () => nonExistentObject,
  width: "300px",
  height: "100px",
};
```

This will in fact fail the render of all widgets and show no error on the canvas. This is because in the current implementation the `render` function is called within the state setter using a updater function, which will be delayed to re-render and thus uncaught. In this PR we call the `render` function in advance to get its returned value so we make sure at least the function itself is correct. Then errors in the returns react component will be caught by the error boundary I believe.