### PR TITLE
FIX manager layout broken on MacOS

### DIFF
--- a/src/manager/App.tsx
+++ b/src/manager/App.tsx
@@ -33,42 +33,49 @@ export default function App({ initialSettings }: ManagerAppProps) {
   useUpdateSettingListener(setManagerWidgetStates);
 
   return (
-    <Theme appearance={themeAppearance} accentColor="indigo" grayColor="slate">
+    <Theme
+      appearance={themeAppearance}
+      accentColor="indigo"
+      grayColor="slate"
+      css={{ height: "100vh" }}
+    >
       <ManagerToaster themeAppearance={themeAppearance} />
       <ThemeAppearanceToggler
         themeAppearance={themeAppearance}
         setThemeAppearance={setThemeAppearance}
       />
-      <Tabs.Root defaultValue="widgets">
-        <Tabs.List>
-          <Tabs.Trigger value="widgets">Widgets</Tabs.Trigger>
-          <Tabs.Trigger value="settings">Settings</Tabs.Trigger>
-          <Tabs.Trigger value="about">About</Tabs.Trigger>
-        </Tabs.List>
-        {/* The body has 480px height and tab triggers have ~40px height */}
-        <Box px="1" py="3" height="440px">
-          <Tabs.Content value="widgets" asChild>
-            <Box height="100%">
-              <WidgetsTab
-                managerWidgetStates={managerWidgetStates}
-                setManagerWidgetStates={setManagerWidgetStates}
-                rescanAndRender={rescanAndRender}
-              />
-            </Box>
-          </Tabs.Content>
-          <Tabs.Content value="settings" asChild>
-            <Box height="100%">
-              <SettingsTab
-                toggleShortcut={toggleShortcut}
-                setToggleShortcut={setToggleShortcut}
-              />
-            </Box>
-          </Tabs.Content>
-          <Tabs.Content value="about" asChild>
-            <Box height="100%">
-              <AboutTab />
-            </Box>
-          </Tabs.Content>
+      <Tabs.Root defaultValue="widgets" asChild>
+        <Box height="100%" p="2">
+          <Tabs.List>
+            <Tabs.Trigger value="widgets">Widgets</Tabs.Trigger>
+            <Tabs.Trigger value="settings">Settings</Tabs.Trigger>
+            <Tabs.Trigger value="about">About</Tabs.Trigger>
+          </Tabs.List>
+          {/* Tab triggers have ~40px height */}
+          <Box px="1" py="3" css={{ height: "calc(100% - 40px)" }}>
+            <Tabs.Content value="widgets" asChild>
+              <Box height="100%">
+                <WidgetsTab
+                  managerWidgetStates={managerWidgetStates}
+                  setManagerWidgetStates={setManagerWidgetStates}
+                  rescanAndRender={rescanAndRender}
+                />
+              </Box>
+            </Tabs.Content>
+            <Tabs.Content value="settings" asChild>
+              <Box height="100%">
+                <SettingsTab
+                  toggleShortcut={toggleShortcut}
+                  setToggleShortcut={setToggleShortcut}
+                />
+              </Box>
+            </Tabs.Content>
+            <Tabs.Content value="about" asChild>
+              <Box height="100%">
+                <AboutTab />
+              </Box>
+            </Tabs.Content>
+          </Box>
         </Box>
       </Tabs.Root>
     </Theme>

--- a/src/manager/components/FloatButton.tsx
+++ b/src/manager/components/FloatButton.tsx
@@ -25,7 +25,7 @@ export default function FloatButton({
   onClick,
 }: FloatButtonProps) {
   return (
-    <Box position="absolute" right="3" bottom={`${(order - 1) * 40}px`}>
+    <Box position="absolute" right="0" bottom={`${(order - 1) * 40}px`}>
       <Tooltip content={tooltip} side="left">
         <IconButton variant="surface" radius="full" onClick={onClick}>
           {icon}

--- a/src/manager/components/ThemeAppearanceToggler.tsx
+++ b/src/manager/components/ThemeAppearanceToggler.tsx
@@ -29,7 +29,7 @@ export default function ThemeAppearanceToggler({
   };
 
   return (
-    <Box position="absolute" right="3" top="2">
+    <Box position="absolute" right="3" top="4">
       <Tooltip
         side="left"
         content={`Switch to ${themeAppearance === "light" ? "dark" : "light"} mode`}

--- a/views/manager.html
+++ b/views/manager.html
@@ -7,8 +7,8 @@
     <title>Deskulpt Manager</title>
   </head>
 
-  <body style="overflow: hidden">
-    <div id="root" style="width: 100%; height: 480px"></div>
+  <body style="overflow: hidden; margin: 0">
+    <div id="root"></div>
     <script type="module" src="/src/manager/main.tsx"></script>
   </body>
 </html>


### PR DESCRIPTION
See https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/pull/62#pullrequestreview-2112259557 and the following image. There is a margin around the body of the window, and also causes the main contents of the window to be mispositioned. This PR should fix both.

![de65c6eb6405dedc3f6bbb94659d3f3](https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/assets/108576690/1bdbb1fd-9daf-498a-8867-f108103e0494)

Pinging @ROMEEZHOU for a review to confirm that the problem is fixed on MacOS.