### PR TITLE
MAINT improve dependabot configuration to avoid spam

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -4,31 +4,79 @@ updates:
   - package-ecosystem: npm
     directory: /
     schedule:
-      interval: daily
+      interval: weekly
+    labels:
+      - dependencies
+    groups:
+      tauri:
+        patterns:
+          - "@tauri-apps/*"
+      dev:
+        dependency-type: development
 
   - package-ecosystem: cargo
     directory: /src-tauri
     schedule:
-      interval: daily
+      interval: weekly
+    labels:
+      - dependencies
+    groups:
+      tauri:
+        patterns:
+          - tauri*
+      swc:
+        patterns:
+          - swc*
+      dev:
+        dependency-type: development
 
   # Deskulpt tooling
   - package-ecosystem: npm
     directory: /tooling/apis
     schedule:
-      interval: daily
+      interval: weekly
+    labels:
+      - dependencies
+    groups:
+      dev:
+        dependency-type: development
 
   - package-ecosystem: npm
     directory: /tooling/react
     schedule:
-      interval: daily
+      interval: weekly
+    labels:
+      - dependencies
+    groups:
+      dev:
+        dependency-type: development
 
   - package-ecosystem: npm
     directory: /tooling/ui
     schedule:
-      interval: daily
+      interval: weekly
+    labels:
+      - dependencies
+    groups:
+      dev:
+        dependency-type: development
 
   # Website
   - package-ecosystem: npm
     directory: /website
     schedule:
-      interval: daily
+      interval: weekly
+    labels:
+      - dependencies
+    groups:
+      docusaurus:
+        patterns:
+          - "@docusaurus/*"
+      dev:
+        dependency-type: development
+
+  # Maintenance
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
Daily schedule is too frequent so this PR switches to weekly update. Besides that, without [grouping](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups) there will be too many PRs open up. Also without specifying [labels](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#labels) default labels will be created which is undesired.

This PR specifies only the `dependencies` label for all such PRs. It also create groups such as `tauri`, `swc`, and `docusaurus`. Also development dependencies are all grouped together. Other production dependencies are still updated individually, though.