### PR TITLE
MAINT fix dependabot failing to update pnpm lockfile in monorepo

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,12 +1,13 @@
 version: 2
 updates:
-  # Core and tooling (frontend)
+  # Node dependencies
   - package-ecosystem: npm
     directories:
       - /
       - /tooling/apis
       - /tooling/react
       - /tooling/ui
+      - /website
     schedule:
       interval: weekly
     labels:
@@ -18,10 +19,14 @@ updates:
       tauri:
         patterns:
           - "@tauri-apps/*"
+      docusaurus:
+        patterns:
+          - "@docusaurus/*"
+          - "docusaurus-plugin-*"
       dev:
         dependency-type: development
 
-  # Core and tooling (backend)
+  # Cargo dependencies
   - package-ecosystem: cargo
     directory: /src-tauri
     schedule:
@@ -38,21 +43,7 @@ updates:
       dev:
         dependency-type: development
 
-  # Website
-  - package-ecosystem: npm
-    directory: /website
-    schedule:
-      interval: weekly
-    labels:
-      - dependencies
-    groups:
-      docusaurus:
-        patterns:
-          - "@docusaurus/*"
-      dev:
-        dependency-type: development
-
-  # Maintenance
+  # GitHub Actions dependencies
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
Dependabot seems to fail when `package.json` is in a subdirectory but `pnpm-lock.yaml` is not. See https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/pull/171 for example, where `package.json` is in `/website`, `pnpm-lock.yaml` is in `/`, and the `directory` configuration of the dependabot is set to `/website`. I assume that if the root is `/` it will be able to do the correct update, which is what this PR does. It's perhaps not the best because then website updates will be mixed with main app updates but that's the only thing I can come up with at this moment. Also xref https://github.com/dependabot/dependabot-core/issues/6346.