### PR TITLE
MAINT build comment workflow should not run on push

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -72,7 +72,7 @@ jobs:
 
   comment:
     needs: build
-    if: ${{ !cancelled() }}
+    if: ${{ !cancelled() && github.event_name == 'pull_request' }}
     runs-on: ubuntu-latest
     permissions:
       issues: write


### PR DESCRIPTION
It makes sense to run the comment workflow only for pull requests. This will also fix the workflow that currently always fails on main, e.g. https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/actions/runs/10580517218/job/29316026387