### PR TITLE
DEP remove `parking_lot` from backend dependencies

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -877,7 +877,6 @@ dependencies = [
  "cargo-llvm-cov",
  "copy_dir",
  "objc",
- "parking_lot",
  "path-clean",
  "pretty_assertions",
  "regex",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -31,7 +31,6 @@ tempfile = "3.12.0"
 sysinfo = "0.31.3"
 
 # SWC crates and related
-parking_lot = "0.12.3"  # Required by swc_ecma_loader
 swc_atoms = "0.6.7"
 swc_bundler = "0.226.0"
 swc_common = "0.33.25"


### PR DESCRIPTION
I cannot remember exactly why `parking_lot` was needed previously (perhaps there's something wrong in the SWC crates e.g. not having a correct dependency tree). But now it seems we no longer need to manually add `parking_lot` - It's pretty clear from the lock file that nothing essentially changes.