### PR TITLE
TST remove unnecessary exact checks from bundler tests

### DIFF
--- a/src-tauri/src/testing.rs
+++ b/src-tauri/src/testing.rs
@@ -52,13 +52,16 @@ pub(crate) fn assert_err_eq(error: Error, chain: Vec<ChainReason>) {
             },
             ChainReason::IOError => {
                 let io_error = reason.downcast_ref::<std::io::Error>();
-                assert!(io_error.is_some(), "Expected an IO error in the error chain");
+                assert!(
+                    io_error.is_some(),
+                    "Expected an IO error in the error chain; got: {reason:?}",
+                );
             },
             ChainReason::SerdeError => {
                 let serde_error = reason.downcast_ref::<serde_json::Error>();
                 assert!(
                     serde_error.is_some(),
-                    "Expected a serde_json error in the error chain",
+                    "Expected a serde_json error in the error chain; got: {reason:?}",
                 );
             },
             ChainReason::Skip => continue,

--- a/src-tauri/src/testing.rs
+++ b/src-tauri/src/testing.rs
@@ -24,7 +24,7 @@ pub(crate) enum ChainReason {
     /// The error reason should be a `serde_json` error.
     SerdeError,
     /// Skip validating the reason.
-    _Skip,
+    Skip,
 }
 
 /// Assert that an [`Error`] object has the expected chain of reasons.
@@ -37,13 +37,17 @@ pub(crate) fn assert_err_eq(error: Error, chain: Vec<ChainReason>) {
 
         match expected_reason {
             ChainReason::Exact(msg) => {
-                assert_eq!(reason.to_string(), msg, "Expected reason: {reason:?}")
+                assert_eq!(
+                    reason.to_string(),
+                    msg,
+                    "Expected reason to be: {msg:?}; got: {reason:?}"
+                );
             },
             ChainReason::Regex(pattern) => {
                 let re = Regex::new(&pattern).unwrap();
                 assert!(
                     re.is_match(&reason.to_string()),
-                    "Expected reason to match pattern: {pattern:?}"
+                    "Expected reason to match pattern: {pattern:?}; got: {reason:?}"
                 );
             },
             ChainReason::IOError => {
@@ -57,7 +61,7 @@ pub(crate) fn assert_err_eq(error: Error, chain: Vec<ChainReason>) {
                     "Expected a serde_json error in the error chain",
                 );
             },
-            ChainReason::_Skip => continue,
+            ChainReason::Skip => continue,
         }
     }
     // Assert that the chain of reasons ends here

--- a/src-tauri/tests/fixtures/bundler/default_deps/input/index.js
+++ b/src-tauri/tests/fixtures/bundler/default_deps/input/index.js
@@ -1,0 +1,5 @@
+import apis from "@deskulpt-test/apis";
+import { css } from "@deskulpt-test/ui";
+import React, { useState } from "@deskulpt-test/react";
+
+console.log(apis, css, React, useState);

--- a/src-tauri/tests/fixtures/bundler/default_deps/output.js
+++ b/src-tauri/tests/fixtures/bundler/default_deps/output.js
@@ -1,0 +1,1 @@
+import apis from"blob://dummy-url";import{css}from"@deskulpt-test/ui";import React,{useState}from"@deskulpt-test/react";console.log(apis,css,React,useState);

--- a/src-tauri/tests/fixtures/bundler/external_deps/input/index.js
+++ b/src-tauri/tests/fixtures/bundler/external_deps/input/index.js
@@ -1,9 +1,0 @@
-// Default dependencies
-import React, { useState } from "@deskulpt-test/react";
-import { css } from "@deskulpt-test/ui";
-
-// External dependencies
-import { matcher } from "matcher";
-import osName from "os-name";
-
-console.log(apis, css, React, useState, matcher, osName);

--- a/src-tauri/tests/fixtures/bundler/external_deps/output.js
+++ b/src-tauri/tests/fixtures/bundler/external_deps/output.js
@@ -1,1 +1,0 @@
-import React,{useState}from"@deskulpt-test/react";import{css}from"@deskulpt-test/ui";import{matcher}from"matcher";import osName from"os-name";console.log(apis,css,React,useState,matcher,osName);

--- a/src-tauri/tests/fixtures/bundler/import_url/input/index.jsx
+++ b/src-tauri/tests/fixtures/bundler/import_url/input/index.jsx
@@ -1,1 +1,1 @@
-import osName from "https://cdn.jsdelivr.net/npm/os-name@6.0.0/+esm";
+import osName from "https://foo.js";

--- a/src-tauri/tests/fixtures/bundler/replace_apis/input/index.js
+++ b/src-tauri/tests/fixtures/bundler/replace_apis/input/index.js
@@ -1,3 +1,0 @@
-import apis from "@deskulpt-test/apis";
-
-console.log(apis);

--- a/src-tauri/tests/fixtures/bundler/replace_apis/output.js
+++ b/src-tauri/tests/fixtures/bundler/replace_apis/output.js
@@ -1,1 +1,0 @@
-import apis from"blob://dummy-url";console.log(apis);


### PR DESCRIPTION
This PR mainly makes the following changes:

- Removed `external_deps` and converted part of it into `default_deps`. The part specifically for external dependencies will be covered in #66 where the new behavior is implemented.
- Combine `replace_apis` into `default_deps` because `@deskulpt-test/apis` is also a default dependency and the complexity clearly allows to use one test for both of them.
- Skip most error messages in the error chain that does not include useful information, such as `load_transformed failed`.
- Use regex for error messages that include paths, URLs, etc. This is mainly to reduce complexity.
- Improve output of `assert_err_eq` a bit to provide more information of what we actually got