### PR TITLE
MAINT fix linter warning of duplicated attributes

### DIFF
--- a/src-tauri/src/testing.rs
+++ b/src-tauri/src/testing.rs
@@ -1,5 +1,3 @@
-#![cfg(test)]
-
 //! This module is provides testing utilities.
 //!
 //! It should not be included except for in test builds.


### PR DESCRIPTION
```
warning: duplicated attribute
  --> src\testing.rs:1:8
   |
1  | #![cfg(test)]
   |        ^^^^
   |
note: first defined here
  --> src/main.rs:26:7
   |
26 | #[cfg(test)]
   |       ^^^^
help: remove this attribute
  --> src\testing.rs:1:8
   |
1  | #![cfg(test)]
   |        ^^^^
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#duplicated_attributes
   = note: `-D clippy::duplicated-attributes` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::duplicated_attributes)]
```

In `main.rs` we have already introduced the `test` module only when `cfg(test)`. There is no need to declare in addition the `test` module as top-level `cfg(test)`.