### PR TITLE
ENH raise when specifying default dependencies as external dependencies

### DIFF
--- a/src-tauri/tests/fixtures/config/default_deps_in_dependencies/deskulpt.conf.json
+++ b/src-tauri/tests/fixtures/config/default_deps_in_dependencies/deskulpt.conf.json
@@ -1,0 +1,5 @@
+{
+  "name": "sample",
+  "entry": "index.jsx",
+  "ignore": false
+}

--- a/src-tauri/tests/fixtures/config/default_deps_in_dependencies/package.json
+++ b/src-tauri/tests/fixtures/config/default_deps_in_dependencies/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "@deskulpt-test/react": "^0.0.4"
+  }
+}


### PR DESCRIPTION
We treat `dependencies` in `package.json` as external dependencies, and default dependencies should not appear in this collection. This is reasonable as default dependencies are only meant for development support (i.e., provide type hints) - semantically they should be `devDependencies` instead. This PR raises if we see default dependencies included in `dependencies`.