### PR TITLE
MAINT apply TypeScript and React transforms directly in path loader

### DIFF
--- a/src-tauri/src/bundler/common.rs
+++ b/src-tauri/src/bundler/common.rs
@@ -21,7 +21,7 @@ use swc_ecma_codegen::{
 };
 use swc_ecma_loader::resolve::Resolution;
 use swc_ecma_parser::{parse_file_as_module, EsConfig, Syntax, TsConfig};
-use swc_ecma_transforms_react::jsx;
+use swc_ecma_transforms_react::react;
 use swc_ecma_transforms_typescript::typescript;
 use swc_ecma_visit::FoldWith;
 use tempfile::NamedTempFile;
@@ -49,6 +49,7 @@ pub(super) fn bundle_into_raw_module(
     let external_modules = {
         let mut dependencies = HashSet::from([
             Atom::from("@deskulpt-test/apis"),
+            Atom::from("@deskulpt-test/emotion/jsx-runtime"),
             Atom::from("@deskulpt-test/react"),
             Atom::from("@deskulpt-test/ui"),
         ]);
@@ -91,45 +92,6 @@ pub(super) fn bundle_into_raw_module(
     Ok(bundles.pop().unwrap().module)
 }
 
-/// Apply basic AST transforms to a module.
-///
-/// This includes stripping off TypeScript types and transforming JSX syntax.
-pub(super) fn apply_basic_transforms(module: Module, cm: Lrc<SourceMap>) -> Module {
-    let top_level_mark = Mark::new();
-    let unresolved_mark = Mark::new();
-
-    // Transform that removes TypeScript types; weirdly, this must be applied on a
-    // program rather than a module; note that we use the verbatim module syntax to
-    // avoid removing unused import statements in case they are needed
-    let mut ts_transform = typescript::typescript(
-        typescript::Config { verbatim_module_syntax: true, ..Default::default() },
-        top_level_mark,
-    );
-    let program = Program::Module(module);
-    let module = program.fold_with(&mut ts_transform).expect_module();
-
-    // We use the automatic JSX transform (in contrast to the classic transform)
-    // here so that there is no need to bring anything into scope just for syntax
-    // which could be unused; to enable the `css` prop from Emotion, we specify the
-    // import source to be `@deskulpt-test/emotion`, so that `jsx`, `jsxs`, and
-    // `Fragment` will be imported from `@deskulpt-test/emotion/jsx-runtime`, which
-    // will then be redirected to `src/.scripts/emotion-react-jsx-runtime.js` that
-    // re-exports necessary runtime functions
-    let mut jsx_transform = jsx::<SingleThreadedComments>(
-        cm.clone(),
-        None,
-        swc_ecma_transforms_react::Options {
-            runtime: Some(swc_ecma_transforms_react::Runtime::Automatic),
-            import_source: Some("@deskulpt-test/emotion".to_string()),
-            ..Default::default()
-        },
-        top_level_mark,
-        unresolved_mark,
-    );
-
-    module.fold_with(&mut jsx_transform)
-}
-
 /// Emit a module into a buffer.
 pub(super) fn emit_module_to_buf<W: Write>(module: Module, cm: Lrc<SourceMap>, buf: W) {
     let wr = JsWriter::new(cm.clone(), "\n", buf, None);
@@ -144,9 +106,8 @@ pub(super) fn emit_module_to_buf<W: Write>(module: Module, cm: Lrc<SourceMap>, b
 
 /// Deskulpt-customized path loader for SWC bundler.
 ///
-/// It is in charge of parsing the source file into a module AST. Note that transforms
-/// are not applied here to avoid messing up per-file ASTs that can cause unexpected
-/// bundling results.
+/// It is in charge of parsing the source file into a module AST. TypeScript types are
+/// stripped off and JSX syntax is transformed during the parsing.
 struct PathLoader(Lrc<SourceMap>);
 
 impl Load for PathLoader {
@@ -164,11 +125,45 @@ impl Load for PathLoader {
             _ => Syntax::Es(EsConfig { jsx: true, ..Default::default() }),
         };
 
-        // Parse the file as a module; note that transformations are not applied here,
-        // because per-file transformations may lead to unexpected results when bundled
-        // together; instead, transformations are postponed until the bundling phase
+        // Parse the file as a module
         match parse_file_as_module(&fm, syntax, Default::default(), None, &mut vec![]) {
-            Ok(module) => Ok(ModuleData { fm, module, helpers: Default::default() }),
+            Ok(module) => {
+                let unresolved_mark = Mark::new();
+                let top_level_mark = Mark::new();
+
+                // Strip off TypeScript types
+                let mut ts_transform =
+                    typescript::typescript(Default::default(), top_level_mark);
+
+                // We use the automatic JSX transform (in contrast to the classic
+                // transform) here so that there is no need to bring anything into scope
+                // just for syntax which could be unused; to enable the `css` prop from
+                // Emotion, we specify the import source to be `@deskulpt-test/emotion`,
+                // so that the JSX runtime utilities will be automatically imported from
+                // `@deskulpt-test/emotion/jsx-runtime`
+                let mut jsx_transform = react::<SingleThreadedComments>(
+                    self.0.clone(),
+                    None,
+                    swc_ecma_transforms_react::Options {
+                        runtime: Some(swc_ecma_transforms_react::Runtime::Automatic),
+                        import_source: Some("@deskulpt-test/emotion".to_string()),
+                        ..Default::default()
+                    },
+                    top_level_mark,
+                    unresolved_mark,
+                );
+
+                match Program::Module(module)
+                    .fold_with(&mut ts_transform)
+                    .fold_with(&mut jsx_transform)
+                    .module()
+                {
+                    Some(module) => {
+                        Ok(ModuleData { fm, module, helpers: Default::default() })
+                    },
+                    None => bail!("Failed to parse the file as a module"),
+                }
+            },
             Err(err) => {
                 // The error handler requires a destination for the emitter writer that
                 // implements `Write`; a buffer implements `Write` but its borrowed

--- a/src-tauri/src/bundler/mod.rs
+++ b/src-tauri/src/bundler/mod.rs
@@ -36,8 +36,6 @@ pub(crate) fn bundle(
     )?;
 
     let code = GLOBALS.set(&globals, || {
-        let module = common::apply_basic_transforms(module, cm.clone());
-
         // We need to rename the imports of `@deskulpt-test/apis` to the blob URL which
         // wraps the widget APIs to avoid exposing the raw APIs that allow specifying
         // widget IDs; note that this transform should be done last to avoid messing up
@@ -208,8 +206,11 @@ mod tests {
         let bundle_root = temp_dir.path().join("input");
         let index_path = bundle_root.join("index.jsx");
         let utils_path = bundle_root.join("utils.js");
-        std::fs::write(&index_path, format!("import {{ foo }} from {utils_path:?};"))
-            .unwrap();
+        std::fs::write(
+            &index_path,
+            format!("import {{ foo }} from {utils_path:?}; console.log(foo);"),
+        )
+        .unwrap();
         std::fs::write(&utils_path, "export const foo = 42;").unwrap();
 
         // Test the bundling error

--- a/src-tauri/tests/fixtures/bundler/import_beyond_root/input/index.jsx
+++ b/src-tauri/tests/fixtures/bundler/import_beyond_root/input/index.jsx
@@ -1,1 +1,2 @@
 import { foo } from "../../foo";
+console.log(foo);

--- a/src-tauri/tests/fixtures/bundler/import_node_modules/input/index.jsx
+++ b/src-tauri/tests/fixtures/bundler/import_node_modules/input/index.jsx
@@ -1,1 +1,2 @@
 import osName from "os-name";
+console.log(osName);

--- a/src-tauri/tests/fixtures/bundler/import_url/input/index.jsx
+++ b/src-tauri/tests/fixtures/bundler/import_url/input/index.jsx
@@ -1,1 +1,2 @@
 import osName from "https://foo.js";
+console.log(osName);

--- a/src-tauri/tests/fixtures/bundler/strip_types/output.js
+++ b/src-tauri/tests/fixtures/bundler/strip_types/output.js
@@ -1,1 +1,1 @@
-import{jsx as _jsx}from"@deskulpt-test/emotion/jsx-runtime";import"@deskulpt-test/react";const render=()=>_jsx("div",{children:"Hello, world!"});const __default={render,width:"100px",height:"100px"};export{__default as default};
+import{jsx as _jsx}from"@deskulpt-test/emotion/jsx-runtime";const render=()=>_jsx("div",{children:"Hello, world!"});const __default={render,width:"100px",height:"100px"};export{__default as default};


### PR DESCRIPTION
Reference: https://github.com/swc-project/swc/blob/f584ef76d75e86da15d0725ac94be35a88a1c946/crates/swc_bundler/tests/common/mod.rs#L90

The main reason is that in newer versions of SWC the bundler seems unable to parse TypeScript syntax directly so it would be better to strip them off early. There's no harm in doing this - it even saves the effort of doing `apply_basic_transforms` everytime after getting the bundled raw module.