### PR TITLE
TST/RFC refactor SWC transforms and add testing

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -82,6 +82,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -929,6 +938,12 @@ name = "diff"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
+name = "difference"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524cbf6897b527295dff137cec09ecf3a05f4fddffd7dfcd1585403449e74198"
 
 [[package]]
 name = "digest"
@@ -2375,6 +2390,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "miette"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4edc8853320c2a0dab800fbda86253c8938f6ea88510dc92c5f1ed20e794afc1"
+dependencies = [
+ "cfg-if",
+ "miette-derive",
+ "owo-colors",
+ "textwrap",
+ "thiserror",
+ "unicode-width",
+]
+
+[[package]]
+name = "miette-derive"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcf09caffaac8068c346b6df2a7fc27a177fd20b39421a39ce0a211bde679a6c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.55",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2747,6 +2787,12 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "owo-colors"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caff54706df99d2a78a5a4e3455ff45448d81ef1bb63c22cd14052ca0e993a3f"
 
 [[package]]
 name = "pango"
@@ -3852,6 +3898,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
 name = "socket2"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4098,13 +4150,16 @@ dependencies = [
  "new_debug_unreachable",
  "num-bigint",
  "once_cell",
+ "parking_lot",
  "rustc-hash",
  "serde",
  "siphasher",
+ "sourcemap",
  "swc_allocator",
  "swc_atoms",
  "swc_eq_ignore_macros",
  "swc_visit",
+ "termcolor",
  "tracing",
  "unicode-width",
  "url",
@@ -4152,6 +4207,7 @@ dependencies = [
  "swc_ecma_parser",
  "swc_ecma_transforms_base",
  "swc_ecma_transforms_react",
+ "swc_ecma_transforms_testing",
  "swc_ecma_transforms_typescript",
  "swc_ecma_visit",
  "vergen",
@@ -4242,6 +4298,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "swc_ecma_testing"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "945faa325af9833b2541d3b0b4e614812677480c2b763c6c6e8c2a42a133b906"
+dependencies = [
+ "anyhow",
+ "hex",
+ "sha2",
+ "testing",
+ "tracing",
+]
+
+[[package]]
 name = "swc_ecma_transforms_base"
 version = "0.145.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4326,6 +4395,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "swc_ecma_transforms_testing"
+version = "0.148.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "902e7dc5033ff3bdaef8961714328a4992a0089b23b16822c51ae6f4968ec682"
+dependencies = [
+ "ansi_term",
+ "anyhow",
+ "base64 0.21.7",
+ "hex",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sourcemap",
+ "swc_common",
+ "swc_ecma_ast",
+ "swc_ecma_codegen",
+ "swc_ecma_parser",
+ "swc_ecma_testing",
+ "swc_ecma_transforms_base",
+ "swc_ecma_utils",
+ "swc_ecma_visit",
+ "tempfile",
+ "testing",
+]
+
+[[package]]
 name = "swc_ecma_transforms_typescript"
 version = "0.198.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4385,6 +4480,19 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.55",
+]
+
+[[package]]
+name = "swc_error_reporters"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d049e9256abf29d9fc66d3db3ea44b6815a64ad565ce31e117a74ee96478bb3"
+dependencies = [
+ "anyhow",
+ "miette",
+ "once_cell",
+ "parking_lot",
+ "swc_common",
 ]
 
 [[package]]
@@ -4877,6 +4985,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "testing"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3105e9569b7f674d1107d19494c993aafd19ea51f7a558b96b267b49c9b5f2bf"
+dependencies = [
+ "ansi_term",
+ "cargo_metadata",
+ "difference",
+ "once_cell",
+ "pretty_assertions",
+ "regex",
+ "serde",
+ "serde_json",
+ "swc_common",
+ "swc_error_reporters",
+ "testing_macros",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "testing_macros"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a39660370116afe46d5ff8bcb01b7afe2140dda3137ef5cb1914681e37a4ee06"
+dependencies = [
+ "anyhow",
+ "glob",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "syn 2.0.55",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d434d3f8967a09480fb04132ebe0a3e088c173e6d0ee7897abbdf4eab0f8b9"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width",
+]
+
+[[package]]
 name = "thin-slice"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5289,6 +5445,12 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-normalization"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -12,6 +12,7 @@ copy_dir = "0.1.3"
 pretty_assertions = "1.4.0"
 regex = "1.10.6"
 rstest = "0.22.0"
+swc_core = { version = "0.102.2", features = ["testing_transform"] }
 
 [dependencies]
 tauri = { version = "2.0.0-rc.8", features = ["macos-private-api", "test", "tray-icon"] }

--- a/src-tauri/src/bundler/mod.rs
+++ b/src-tauri/src/bundler/mod.rs
@@ -42,9 +42,7 @@ pub(crate) fn bundle(
         // wraps the widget APIs to avoid exposing the raw APIs that allow specifying
         // widget IDs; note that this transform should be done last to avoid messing up
         // with import resolution
-        let mut wrap_apis = as_folder(transforms::ImportRenamer(
-            [("@deskulpt-test/apis".to_string(), apis_blob_url)].into(),
-        ));
+        let mut wrap_apis = as_folder(transforms::ApisImportRenamer(apis_blob_url));
         let module = module.fold_with(&mut wrap_apis);
 
         // Emit the bundled module as string into a buffer

--- a/src-tauri/src/bundler/transforms.rs
+++ b/src-tauri/src/bundler/transforms.rs
@@ -1,29 +1,40 @@
 //! This module implements custom AST transforms.
 
-use std::collections::HashMap;
-
-use swc_core::{
-    atoms::Atom,
-    ecma::{
-        ast::ModuleDecl,
-        visit::{noop_visit_mut_type, VisitMut, VisitMutWith},
-    },
+use swc_core::ecma::{
+    ast::ImportDecl,
+    visit::{noop_visit_mut_type, VisitMut, VisitMutWith},
 };
 
-/// An AST transformer that renames import module specifiers.
-pub(super) struct ImportRenamer(pub(super) HashMap<String, String>);
+/// An AST transformer that redirects widget APIs imports to the specified blob URL.
+pub(super) struct ApisImportRenamer(
+    /// The blob URL to redirect APIs imports to.
+    pub(super) String,
+);
 
-impl VisitMut for ImportRenamer {
+impl VisitMut for ApisImportRenamer {
     noop_visit_mut_type!();
 
-    fn visit_mut_module_decl(&mut self, n: &mut ModuleDecl) {
+    fn visit_mut_import_decl(&mut self, n: &mut ImportDecl) {
         n.visit_mut_children_with(self);
 
-        if let ModuleDecl::Import(import_decl) = n {
-            let src = import_decl.src.value.to_string();
-            if let Some(new_src) = self.0.get(&src) {
-                import_decl.src.value = Atom::from(new_src.clone());
-            }
+        if n.src.value.as_str() == "@deskulpt-test/apis" {
+            n.src = Box::new(self.0.clone().into());
         }
     }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use swc_core::ecma::{transforms::testing::test_inline, visit::as_folder};
+
+    // Test that the `ApisImportRenamer` transformer correctly renames the imports of
+    // `@deskulpt-test/apis` to the specified blob URL
+    test_inline!(
+        Default::default(),
+        |_| as_folder(ApisImportRenamer("blob://dummy-url".into())),
+        test_transform_apis_import_renamer,
+        r#"import "@deskulpt-test/apis";"#,
+        r#"import "blob://dummy-url";"#
+    );
 }


### PR DESCRIPTION
This adds unit tests to the SWC transforms using the SWC testing utilities. These tests are at a finer granularity than those in `mod.rs` and can help better identify if we are implementing bad transforms or there's something else going wrong.