### PR TITLE
MAINT make tauri test feature only dev dependency

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -13,9 +13,10 @@ pretty_assertions = "1.4.0"
 regex = "1.10.6"
 rstest = "0.22.0"
 swc_core = { version = "0.102.2", features = ["testing_transform"] }
+tauri = { version = "2.0.0-rc.8", features = ["test"] }
 
 [dependencies]
-tauri = { version = "2.0.0-rc.8", features = ["macos-private-api", "test", "tray-icon"] }
+tauri = { version = "2.0.0-rc.8", features = ["macos-private-api", "tray-icon"] }
 tauri-plugin-clipboard-manager = "2.1.0-beta.7"
 tauri-plugin-global-shortcut = "2.0.0-rc.2"
 tauri-plugin-shell = "2.0.0-rc.3"


### PR DESCRIPTION
This is a very minor change as described in the title.

Probably just making release build a bit faster? But at least this is more *semantically* correct.