### PR TITLE
MAINT switch to nightly toolchain with new rustfmt rules

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,7 +1,22 @@
+cargo-features = ["profile-rustflags", "trim-paths"]
+
 [package]
 name = "deskulpt"
 version = "0.0.0"
 edition = "2021"
+
+[profile.dev]
+incremental = true
+rustflags = ["-Zthreads=8"]
+
+[profile.release]
+codegen-units = 1
+lto = true
+opt-level = 3
+panic = "abort"
+strip = true
+trim-paths = "all"
+rustflags = ["-Cdebuginfo=0", "-Zthreads=8"]
 
 [build-dependencies]
 tauri-build = { version = "2.0.0-beta.13", features = ["codegen"] }

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -10,8 +10,15 @@ const INTERNAL_COMMANDS: &[&str] = &[
 ];
 
 const WIDGET_APIS_FS_COMMANDS: &[&str] = &[
-    "is_file", "is_dir", "exists", "read_file", "write_file", "append_file",
-    "remove_file", "create_dir", "remove_dir",
+    "is_file",
+    "is_dir",
+    "exists",
+    "read_file",
+    "write_file",
+    "append_file",
+    "remove_file",
+    "create_dir",
+    "remove_dir",
 ];
 
 const WIDGET_APIS_SYS_COMMANDS: &[&str] = &["get_system_info"];
@@ -20,8 +27,14 @@ fn main() {
     try_build(
         Attributes::new()
             .codegen(CodegenContext::new())
-            .plugin("apis-fs", InlinedPlugin::new().commands(WIDGET_APIS_FS_COMMANDS))
-            .plugin("apis-sys", InlinedPlugin::new().commands(WIDGET_APIS_SYS_COMMANDS))
+            .plugin(
+                "apis-fs",
+                InlinedPlugin::new().commands(WIDGET_APIS_FS_COMMANDS),
+            )
+            .plugin(
+                "apis-sys",
+                InlinedPlugin::new().commands(WIDGET_APIS_SYS_COMMANDS),
+            )
             .app_manifest(AppManifest::new().commands(INTERNAL_COMMANDS)),
     )
     .expect("Failed to run tauri-build");

--- a/src-tauri/rust-toolchain.toml
+++ b/src-tauri/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly-2024-12-19"

--- a/src-tauri/rustfmt.toml
+++ b/src-tauri/rustfmt.toml
@@ -1,20 +1,6 @@
 edition = "2021"
 
+group_imports = "StdExternalCrate"
+imports_granularity = "Module"
 match_block_trailing_comma = true
-newline_style = "Unix"
-use_field_init_shorthand = true
-use_small_heuristics = "Off"
-use_try_shorthand = true
-
-max_width = 88
-array_width = 88
-attr_fn_like_width = 88
-chain_width = 88
-fn_call_width = 88
-single_line_if_else_max_width = 88
-single_line_let_else_max_width = 88
-struct_lit_width = 88
-struct_variant_width = 88
-
-tab_spaces = 4
-short_array_element_width_threshold = 20
+wrap_comments = true

--- a/src-tauri/src/apis/fs/apis.rs
+++ b/src-tauri/src/apis/fs/apis.rs
@@ -1,10 +1,13 @@
 //! This module implements the commands for `fs` in `@deskulpt-test/apis`.
 
-use super::utils::get_resource_path;
-use crate::{cmderr, commands::CommandOut};
-use anyhow::Context;
 use std::io::Write;
+
+use anyhow::Context;
 use tauri::{command, AppHandle, Runtime};
+
+use super::utils::get_resource_path;
+use crate::cmderr;
+use crate::commands::CommandOut;
 
 #[command]
 pub(crate) async fn exists<R: Runtime>(
@@ -98,7 +101,10 @@ pub(crate) async fn create_dir<R: Runtime>(
 ) -> CommandOut<()> {
     let folder_path = get_resource_path(&app_handle, &widget_id, &path)?;
     std::fs::create_dir_all(&folder_path)
-        .context(format!("Failed to create directory '{}'", folder_path.display()))
+        .context(format!(
+            "Failed to create directory '{}'",
+            folder_path.display()
+        ))
         .map_err(|e| cmderr!(e))
 }
 
@@ -110,23 +116,27 @@ pub(crate) async fn remove_dir<R: Runtime>(
 ) -> CommandOut<()> {
     let folder_path = get_resource_path(&app_handle, &widget_id, &path)?;
     std::fs::remove_dir_all(&folder_path)
-        .context(format!("Failed to delete directory '{}'", folder_path.display()))
+        .context(format!(
+            "Failed to delete directory '{}'",
+            folder_path.display()
+        ))
         .map_err(|e| cmderr!(e))
 }
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use crate::testing::setup_mock_env;
+    use std::path::{Path, PathBuf};
+
     use pretty_assertions::assert_eq;
     use rstest::rstest;
-    use std::path::{Path, PathBuf};
+
+    use super::*;
+    use crate::testing::setup_mock_env;
 
     /// Set up a widget directory with the given ID.
     fn setup_widget_directory(base_dir: &Path, widget_id: &str) -> PathBuf {
         let widget_dir = base_dir.join("widgets").join(widget_id);
-        std::fs::create_dir_all(&widget_dir)
-            .expect("Failed to create widget directory");
+        std::fs::create_dir_all(&widget_dir).expect("Failed to create widget directory");
         widget_dir
     }
 
@@ -190,14 +200,20 @@ mod tests {
         assert!(!result.unwrap());
 
         // Check that `is_file` gives false and `is_dir` gives true for the directory
-        let result =
-            is_file(app_handle.clone(), "dummy".to_string(), "dummy_dir".to_string())
-                .await;
+        let result = is_file(
+            app_handle.clone(),
+            "dummy".to_string(),
+            "dummy_dir".to_string(),
+        )
+        .await;
         assert!(result.is_ok());
         assert!(!result.unwrap());
-        let result =
-            is_dir(app_handle.clone(), "dummy".to_string(), "dummy_dir".to_string())
-                .await;
+        let result = is_dir(
+            app_handle.clone(),
+            "dummy".to_string(),
+            "dummy_dir".to_string(),
+        )
+        .await;
         assert!(result.is_ok());
         assert!(result.unwrap());
     }
@@ -217,9 +233,9 @@ mod tests {
         )
         .await;
         assert!(result.is_err());
-        assert!(result.unwrap_err().contains(
-            format!("Failed to read file '{}'", file_path.display()).as_str()
-        ));
+        assert!(result
+            .unwrap_err()
+            .contains(format!("Failed to read file '{}'", file_path.display()).as_str()));
 
         // Create the file with some content and should return the content
         let content = "Hello, world!";

--- a/src-tauri/src/apis/fs/mod.rs
+++ b/src-tauri/src/apis/fs/mod.rs
@@ -1,10 +1,7 @@
 //! The widget API plugin for `fs` in `@deskulpt-test/apis`.
 
-use tauri::{
-    generate_handler,
-    plugin::{Builder, TauriPlugin},
-    Runtime,
-};
+use tauri::plugin::{Builder, TauriPlugin};
+use tauri::{generate_handler, Runtime};
 
 mod apis;
 mod utils;

--- a/src-tauri/src/apis/fs/utils.rs
+++ b/src-tauri/src/apis/fs/utils.rs
@@ -1,9 +1,12 @@
 //! This module contains the utilities for `fs` in `@deskulpt-test/apis`.
 
-use crate::{cmdbail, states::WidgetBaseDirectoryState};
-use path_clean::PathClean;
 use std::path::PathBuf;
+
+use path_clean::PathClean;
 use tauri::{AppHandle, Manager, Runtime};
+
+use crate::cmdbail;
+use crate::states::WidgetBaseDirectoryState;
 
 /// Validate the file system resource (file or folder) path.
 ///
@@ -17,8 +20,8 @@ use tauri::{AppHandle, Manager, Runtime};
 ///
 /// - $widget_base/$widget_id/$path is not within the widget directory
 ///
-/// Note, however, that this function does not check if the resource exists or not,
-/// since the file or folder may not exist yet, and could be created later.
+/// Note, however, that this function does not check if the resource exists or
+/// not, since the file or folder may not exist yet, and could be created later.
 pub(super) fn get_resource_path<R: Runtime>(
     app_handle: &AppHandle<R>,
     widget_id: &str,
@@ -53,16 +56,17 @@ pub(super) fn get_resource_path<R: Runtime>(
 
 #[cfg(test)]
 mod tests {
+    use std::path::{Path, PathBuf};
+
+    use rstest::rstest;
+
     use super::*;
     use crate::testing::setup_mock_env;
-    use rstest::rstest;
-    use std::path::{Path, PathBuf};
 
     /// Set up a widget directory with the given ID.
     fn setup_widget_directory(base_dir: &Path, widget_id: &str) -> PathBuf {
         let widget_dir = base_dir.join("widgets").join(widget_id);
-        std::fs::create_dir_all(&widget_dir)
-            .expect("Failed to create widget directory");
+        std::fs::create_dir_all(&widget_dir).expect("Failed to create widget directory");
         widget_dir
     }
 
@@ -101,10 +105,7 @@ mod tests {
         let dir_path = widget_dir.join("dummy/subdummy");
         std::fs::create_dir_all(dir_path).unwrap();
     })]
-    fn test_get_resource_path_invalid_id(
-        #[case] widget_id: &str,
-        #[case] setup: fn(PathBuf),
-    ) {
+    fn test_get_resource_path_invalid_id(#[case] widget_id: &str, #[case] setup: fn(PathBuf)) {
         // Test that `get_resource_path` raises an error when the widget ID is invalid
         let (base_dir, app_handle) = setup_mock_env();
         let widget_base = base_dir.path().join("widgets");

--- a/src-tauri/src/apis/mod.rs
+++ b/src-tauri/src/apis/mod.rs
@@ -1,4 +1,5 @@
-//! This module is the collection of all widget API plugins for `@deskulpt-test/apis`.
+//! This module is the collection of all widget API plugins for
+//! `@deskulpt-test/apis`.
 
 pub(crate) mod fs;
 pub(crate) mod sys;

--- a/src-tauri/src/apis/sys/apis.rs
+++ b/src-tauri/src/apis/sys/apis.rs
@@ -1,16 +1,18 @@
 //! This module implements the commands for `fs` in `@deskulpt-test/apis`.
 
-use crate::commands::CommandOut;
 use async_std::sync::Mutex;
 use once_cell::sync::Lazy;
 use serde::Serialize;
 use sysinfo::{Disks, Networks, System};
 use tauri::command;
 
+use crate::commands::CommandOut;
+
 /// A System instance shared between all the commands.
 ///
-/// We share a single system instance instead of creating it everytime a command is called.
-/// This is to get a more accurate usage (see doc https://docs.rs/sysinfo/latest/sysinfo/#usage)
+/// We share a single system instance instead of creating it everytime a command
+/// is called. This is to get a more accurate usage; see
+/// https://docs.rs/sysinfo/latest/sysinfo/#usage
 static SYSINFO: Lazy<Mutex<System>> = Lazy::new(|| Mutex::new(System::new_all()));
 
 #[derive(Serialize)]

--- a/src-tauri/src/apis/sys/mod.rs
+++ b/src-tauri/src/apis/sys/mod.rs
@@ -1,10 +1,7 @@
 //! The widget API plugin for `sys` in `@deskulpt-test/apis`.
 
-use tauri::{
-    generate_handler,
-    plugin::{Builder, TauriPlugin},
-    Runtime,
-};
+use tauri::plugin::{Builder, TauriPlugin};
+use tauri::{generate_handler, Runtime};
 
 mod apis;
 

--- a/src-tauri/src/bundler/transforms.rs
+++ b/src-tauri/src/bundler/transforms.rs
@@ -1,11 +1,9 @@
 //! This module implements custom AST transforms.
 
-use swc_core::ecma::{
-    ast::ImportDecl,
-    visit::{noop_visit_mut_type, VisitMut, VisitMutWith},
-};
+use swc_core::ecma::ast::ImportDecl;
+use swc_core::ecma::visit::{noop_visit_mut_type, VisitMut, VisitMutWith};
 
-/// An AST transformer that redirects widget APIs imports to the specified blob URL.
+/// An AST transformer that redirects widget APIs imports to a blob URL.
 pub(super) struct ApisImportRenamer(
     /// The blob URL to redirect APIs imports to.
     pub(super) String,
@@ -25,11 +23,13 @@ impl VisitMut for ApisImportRenamer {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-    use swc_core::ecma::{transforms::testing::test_inline, visit::as_folder};
+    use swc_core::ecma::transforms::testing::test_inline;
+    use swc_core::ecma::visit::as_folder;
 
-    // Test that the `ApisImportRenamer` transformer correctly renames the imports of
-    // `@deskulpt-test/apis` to the specified blob URL
+    use super::*;
+
+    // Test that the `ApisImportRenamer` transformer correctly renames the imports
+    // of `@deskulpt-test/apis` to the specified blob URL
     test_inline!(
         Default::default(),
         |_| as_folder(ApisImportRenamer("blob://dummy-url".into())),

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -9,10 +9,9 @@
     html_favicon_url = "https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/raw/main/src-tauri/icons/icon.png"
 )]
 
-use tauri::{generate_handler, tauri_build_context, Builder, Manager};
-
 #[cfg(target_os = "macos")]
 use tauri::ActivationPolicy;
+use tauri::{generate_handler, tauri_build_context, Builder, Manager};
 
 mod apis;
 mod bundler;
@@ -31,7 +30,9 @@ fn main() {
     Builder::default()
         // Additional application setup
         .setup(|app| {
-            app.manage(states::WidgetBaseDirectoryState::init(app.path().app_data_dir().unwrap()));
+            app.manage(states::WidgetBaseDirectoryState::init(
+                app.path().app_data_dir().unwrap(),
+            ));
             setup::init_system_tray(app)?;
             setup::create_canvas(app)?;
 

--- a/src-tauri/src/settings.rs
+++ b/src-tauri/src/settings.rs
@@ -1,13 +1,14 @@
-//! This module invludes the global and per-widget settings and relevant utilities.
+//! This module invludes the global and per-widget settings and relevant
+//! utilities.
 
-use crate::utils::IdMap;
+use std::fs::{create_dir_all, read_to_string, File};
+use std::io::BufWriter;
+use std::path::Path;
+
 use anyhow::Error;
 use serde::{Deserialize, Serialize};
-use std::{
-    fs::{create_dir_all, read_to_string, File},
-    io::BufWriter,
-    path::Path,
-};
+
+use crate::utils::IdMap;
 
 /// The theme appearance.
 #[derive(Default, Deserialize, Serialize)]
@@ -32,8 +33,8 @@ pub(crate) struct Settings {
 
 /// The per-widget settings.
 ///
-/// These are the settings that are not controlled by the configuration file but rather
-/// controlled directly by the frontend.
+/// These are the settings that are not controlled by the configuration file but
+/// rather controlled directly by the frontend.
 #[derive(Deserialize, Serialize)]
 pub(crate) struct WidgetSetting {
     /// The x-coordinate of the widget in pixels.
@@ -46,8 +47,9 @@ pub(crate) struct WidgetSetting {
 
 /// Read the widget internals.
 ///
-/// This looks for `${app_config_dir}/.settings.json` and returns the widget internals
-/// if the file exists and can be loaded correctly. Otherwise it returns an empty map.
+/// This looks for `${app_config_dir}/.settings.json` and returns the widget
+/// internals if the file exists and can be loaded correctly. Otherwise it
+/// returns an empty map.
 pub(crate) fn read_settings(app_config_dir: &Path) -> Settings {
     let settings_path = app_config_dir.join(".settings.json");
     if !settings_path.exists() {
@@ -61,15 +63,13 @@ pub(crate) fn read_settings(app_config_dir: &Path) -> Settings {
 
 /// Write the widget internals.
 ///
-/// This writes the widget internals to `${app_config_dir}/.settings.json`. It will
-/// create the file if it does not exist, and overwrite the file if it does.
-pub(crate) fn write_settings(
-    app_config_dir: &Path,
-    settings: &Settings,
-) -> Result<(), Error> {
-    // On certain platform, if the file directory does not exist, file creation using std::fs:;File::create will fail.
-    // See [the doc](https://doc.rust-lang.org/std/fs/struct.File.html#method.create) for detail.
-    // Thus we need to manually create app_config_dir if it doesn't exist.
+/// This writes the widget internals to `${app_config_dir}/.settings.json`. It
+/// will create the file if it does not exist, and overwrite the file if it
+/// does.
+pub(crate) fn write_settings(app_config_dir: &Path, settings: &Settings) -> Result<(), Error> {
+    // On certain platform, if the file directory does not exist, file creation
+    // using std::fs::File::create will fail, in which case we need to manually
+    // create the directory; see https://doc.rust-lang.org/std/fs/struct.File.html#method.create
     if !app_config_dir.exists() {
         create_dir_all(app_config_dir)?;
     }

--- a/src-tauri/src/states.rs
+++ b/src-tauri/src/states.rs
@@ -1,23 +1,29 @@
 //! The module provides the types for state management in Tauri.
 //!
-//! In Tauri, different states are distinguished by their unique types, thus we always
-//! use structs to mark the states.
+//! In Tauri, different states are distinguished by their unique types, thus we
+//! always use structs to mark the states.
+
+use std::fs::create_dir_all;
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+use tauri::menu::MenuItem;
+use tauri::Runtime;
 
 use crate::config::WidgetConfigCollection;
-use std::{fs::create_dir_all, path::PathBuf, sync::Mutex};
-use tauri::{menu::MenuItem, Runtime};
 
 /// The type for the state of the collection of widget configurations.
 ///
-/// The managed state will be updated at runtime and is thus protected by a mutex.
+/// The managed state will be updated at runtime and is thus protected by a
+/// mutex.
 #[derive(Default)]
 pub(crate) struct WidgetConfigCollectionState(pub(crate) Mutex<WidgetConfigCollection>);
 
 /// The type for the state of the widget base directory.
 ///
-/// This contains the path to the base directory `$APPDATA/widgets/` where all widgets
-/// should be locally stored. This state is static and should not be changed during the
-/// runtime.
+/// This contains the path to the base directory `$APPDATA/widgets/` where all
+/// widgets should be locally stored. This state is static and should not be
+/// changed during the runtime.
 pub(crate) struct WidgetBaseDirectoryState(pub(crate) PathBuf);
 
 impl WidgetBaseDirectoryState {
@@ -44,12 +50,14 @@ pub(crate) struct CanvasClickThrough<R: Runtime> {
 impl<R: Runtime> CanvasClickThrough<R> {
     /// Try to toggle the canvas click-through state.
     ///
-    /// This is guaranteed to update whether the canvas is click-through or not. It may,
-    /// however, fail to update the menu item text without an error beccause it is not
-    /// worth panicking for such a minor thing.
+    /// This is guaranteed to update whether the canvas is click-through or not.
+    /// It may, however, fail to update the menu item text without an error
+    /// beccause it is not worth panicking for such a minor thing.
     pub(crate) fn toggle(&mut self) {
         self.yes = !self.yes;
-        let _ = self.menu_item.set_text(if self.yes { "Float" } else { "Sink" });
+        let _ = self
+            .menu_item
+            .set_text(if self.yes { "Float" } else { "Sink" });
     }
 
     /// Get whether the canvas is click-through.
@@ -60,14 +68,16 @@ impl<R: Runtime> CanvasClickThrough<R> {
 
 /// The type for the state of whether the canvas can be clicked through.
 ///
-/// The managed state will be updated at runtime and is thus protected by a mutex.
-pub(crate) struct CanvasClickThroughState<R: Runtime>(
-    pub(crate) Mutex<CanvasClickThrough<R>>,
-);
+/// The managed state will be updated at runtime and is thus protected by a
+/// mutex.
+pub(crate) struct CanvasClickThroughState<R: Runtime>(pub(crate) Mutex<CanvasClickThrough<R>>);
 
 impl<R: Runtime> CanvasClickThroughState<R> {
     /// Initialize the canvas click-through state.
     pub(crate) fn init(is_click_through: bool, menu_item: MenuItem<R>) -> Self {
-        Self(Mutex::new(CanvasClickThrough { yes: is_click_through, menu_item }))
+        Self(Mutex::new(CanvasClickThrough {
+            yes: is_click_through,
+            menu_item,
+        }))
     }
 }

--- a/src-tauri/src/testing.rs
+++ b/src-tauri/src/testing.rs
@@ -2,15 +2,14 @@
 //!
 //! It should not be included except for in test builds.
 
-use crate::states::{WidgetBaseDirectoryState, WidgetConfigCollectionState};
 use anyhow::Error;
 use pretty_assertions::assert_eq;
 use regex::Regex;
-use tauri::{
-    test::{mock_app, MockRuntime},
-    AppHandle, Manager,
-};
+use tauri::test::{mock_app, MockRuntime};
+use tauri::{AppHandle, Manager};
 use tempfile::{tempdir, TempDir};
+
+use crate::states::{WidgetBaseDirectoryState, WidgetConfigCollectionState};
 
 pub(crate) enum ChainReason {
     /// The error reason should be exactly equal to the given string.
@@ -66,21 +65,25 @@ pub(crate) fn assert_err_eq(error: Error, chain: Vec<ChainReason>) {
         }
     }
     // Assert that the chain of reasons ends here
-    assert!(error_chain.next().is_none(), "Expected no more reason in the error chain");
+    assert!(
+        error_chain.next().is_none(),
+        "Expected no more reason in the error chain"
+    );
 }
 
 /// Setup a mock environment for testing.
 ///
 /// This function does the following:
 ///
-/// - Creates a temporary directory that serves as the base directory for the mock
-///   environment. It should be used the same as `$APPDATA`, `$APPCONFIG`, etc. The
-///   `TempDir` object itself is returned, because it will be deleted once it goes out
-///   of scope.
+/// - Creates a temporary directory that serves as the base directory for the
+///   mock environment. It should be used the same as `$APPDATA`, `$APPCONFIG`,
+///   etc. The `TempDir` object itself is returned, because it will be deleted
+///   once it goes out of scope.
 ///
-/// - Creates a mock Tauri application. The mock application manages the widget base
-///   directory state, which is `$MOCKBASE/widgets`. It also manages an empty widget
-///   configuration collection state. A handle to this mock application is returned.
+/// - Creates a mock Tauri application. The mock application manages the widget
+///   base directory state, which is `$MOCKBASE/widgets`. It also manages an
+///   empty widget configuration collection state. A handle to this mock
+///   application is returned.
 pub(crate) fn setup_mock_env() -> (TempDir, AppHandle<MockRuntime>) {
     let temp_dir = tempdir().expect("Failed to create temporary directory");
     let mock_base_dir = temp_dir.path().to_path_buf();

--- a/src-tauri/src/utils.rs
+++ b/src-tauri/src/utils.rs
@@ -1,10 +1,12 @@
 //! This module contains utilities that does not fit into any other module.
 
-use crate::states::CanvasClickThroughState;
+use std::collections::HashMap;
+
 use anyhow::{bail, Error};
 use serde::Serialize;
-use std::collections::HashMap;
 use tauri::{AppHandle, Emitter, Manager, Runtime};
+
+use crate::states::CanvasClickThroughState;
 
 /// Mapping from widget IDs to corresponding data.
 pub(crate) type IdMap<T> = HashMap<String, T>;
@@ -25,9 +27,9 @@ struct ShowToastPayload {
 
 /// Toggle the click-through state of the canvas window.
 ///
-/// This will toggle whether the canvas window ignores cursor events and update the
-/// state accordingly. If the canvas is toggled to not click-through, it will try to
-/// regain focus automatically. The function will fail if:
+/// This will toggle whether the canvas window ignores cursor events and update
+/// the state accordingly. If the canvas is toggled to not click-through, it
+/// will try to regain focus automatically. The function will fail if:
 ///
 /// - The canvas window is not found.
 /// - Fails to set the canvas to ignore/unignore cursor events.
@@ -50,7 +52,8 @@ pub(crate) fn toggle_click_through_state<R: Runtime>(
     // If the canvas is previously click-through, meaning that it is now set to not
     // click-through, try to regain focus to avoid flickering on the first click
     if prev_can_click_through {
-        let _ = canvas.set_focus(); // Consume any error because this is not critical
+        let _ = canvas.set_focus(); // Consume any error because this is not
+                                    // critical
     }
 
     // Try to let canvas show the toast message
@@ -61,7 +64,11 @@ pub(crate) fn toggle_click_through_state<R: Runtime>(
             kind: ToastKind::Success,
             message: format!(
                 "Canvas {}.",
-                if prev_can_click_through { "floated" } else { "sunk" }
+                if prev_can_click_through {
+                    "floated"
+                } else {
+                    "sunk"
+                }
             ),
         },
     );


### PR DESCRIPTION
This PR switches to use Rust nightly toolchain (previously we are using stable which is the default). The nightly toolchain ships latest features and gives us more flexibility in development. There are already two benefits that it brings included in this PR:

- See https://v2.tauri.app/concept/size/#cargo-configuration (nightly tab). Nightly toolchain supports more Cargo features, one of which is `rustflags` so that now we can compile with multithreading (`-Zthreads=8`). I also took other configurations options from the link above for now.
- Better `rustfmt` rules, referring to https://github.com/pola-rs/polars/blob/main/rustfmt.toml. Import-related configurations reduce git conflicts by splitting imports by modules into multilines and make them more organized by grouping into std, external, and crate. Comment-related configurations allow wrapping comments in markdown fashion (I remember Xinyu has complained why Rust cannot auto-format comments previously). BTW with this opportunity I also removed the manual line width configurations - let's use Rust's default (I browsed through various famous libraries and applications built in Rust and this is what they do).

Nightly might have breaking changes, but note that we are not aggressively updating nightly every day with some CI but pinning in rust toolchain instead, which provides a much more reliable compilation environment that is less likely to break. I would expect the nightly version in toolchain to be updated manually, where we can periodically check if there are features that we want and determine if we want an update.

Also we are not a crate for downstream consumption but just an app developed in Rust, so we don't really need to worry that much about stability, or about the nightly toolchain being propagated to downstream consumers. I imagine that we may reorganize our repo into multi-crates, and possibly expose a plugin/protocol crate for plugin development in the future, but that does not seem to be an issue either, at least for now.