### PR TITLE
MAINT group all dependabot updates for each type to reduce noises

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,5 +1,20 @@
 version: 2
 updates:
+  # Rust dependencies
+  - package-ecosystem: cargo
+    directory: /src-tauri
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
+    groups:
+      all:
+        patterns:
+          - "*"
+
   # Node dependencies
   - package-ecosystem: npm
     directories:
@@ -7,41 +22,44 @@ updates:
       - /tooling/apis
       - /tooling/react
       - /tooling/ui
-      - /website
     schedule:
       interval: weekly
     labels:
       - dependencies
     ignore:
-      - dependency-name: "eslint"
-        versions: ["9.x"]
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
     groups:
-      tauri:
+      all:
         patterns:
-          - "@tauri-apps/*"
-      docusaurus:
-        patterns:
-          - "@docusaurus/*"
-          - "docusaurus-plugin-*"
-      dev:
-        dependency-type: development
+          - "*"
 
-  # Cargo dependencies
-  - package-ecosystem: cargo
-    directory: /src-tauri
+  # Documentation dependencies
+  - package-ecosystem: npm
+    directory: /website
     schedule:
       interval: weekly
     labels:
       - dependencies
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
     groups:
-      tauri:
+      all:
         patterns:
-          - tauri*
-      dev:
-        dependency-type: development
+          - "*"
 
-  # GitHub Actions dependencies
+  # CI dependencies
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
+    labels:
+      - dependencies
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-patch"]
+    groups:
+      all:
+        patterns:
+          - "*"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -11,7 +11,7 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"]
     groups:
-      all:
+      rust:
         patterns:
           - "*"
 
@@ -30,7 +30,7 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"]
     groups:
-      all:
+      node:
         patterns:
           - "*"
 
@@ -45,7 +45,7 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"]
     groups:
-      all:
+      documentation:
         patterns:
           - "*"
 
@@ -60,6 +60,6 @@ updates:
       - dependency-name: "*"
         update-types: ["version-update:semver-patch"]
     groups:
-      all:
+      ci:
         patterns:
           - "*"


### PR DESCRIPTION
We are having far too many noises. It should be okay to group all.

Note that this partially refers to the polars dependabot configuration: https://github.com/pola-rs/polars/blob/main/.github/dependabot.yml