### PR TITLE
MAINT workaround dependabot issue with pnpm workspace for doc group

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -16,12 +16,17 @@ updates:
           - "*"
 
   # Node dependencies
+  # TODO: Documentation dependencies should have a separate group, but we cannot
+  # because of the issue with pnpm workspace:
+  # https://github.com/dependabot/dependabot-core/issues/7501
+  # We may also want to rework the documentation setup in the future
   - package-ecosystem: npm
     directories:
       - /
       - /tooling/apis
       - /tooling/react
       - /tooling/ui
+      - /website
     schedule:
       interval: weekly
     labels:
@@ -31,21 +36,6 @@ updates:
         update-types: ["version-update:semver-patch"]
     groups:
       node:
-        patterns:
-          - "*"
-
-  # Documentation dependencies
-  - package-ecosystem: npm
-    directory: /website
-    schedule:
-      interval: weekly
-    labels:
-      - dependencies
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
-    groups:
-      documentation:
         patterns:
           - "*"
 


### PR DESCRIPTION
As written in the comment, due to this https://github.com/dependabot/dependabot-core/issues/7501 website group only updates package.json but not pnpm lock in the root since it is not able to detect the root pnpm workspace and pnpm lock files.

The issue has already been stale for over a year and is not likely going to get resolved any time soon. We may want to reorganize the documentation in the future, possibly isolate its dependencies, or even put it into another dedicated repository.