### PR TITLE
MAINT use absolute path with import alias for frontend

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -40,7 +40,7 @@ jobs:
           tagName: v__VERSION__
           releaseName: "Deskulpt v__VERSION__"
           releaseDraft: true
-          prerelease: true
+          prerelease: false
           releaseBody: |
             ## Download Deskulpt v__VERSION__
 

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ dist-ssr
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json
+!.vscode/settings.json
 .idea
 .DS_Store
 *.suo

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,7 @@
 {
-  "recommendations": ["tauri-apps.tauri-vscode", "rust-lang.rust-analyzer"]
+  "recommendations": [
+    "tauri-apps.tauri-vscode",
+    "rust-lang.rust-analyzer",
+    "tamasfe.even-better-toml"
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+  // Auto imports will use the paths as defined in tsconfig.json
+  "typescript.preferences.importModuleSpecifier": "non-relative"
+}

--- a/packages/apis/eslint.config.js
+++ b/packages/apis/eslint.config.js
@@ -1,8 +1,5 @@
 // @ts-check
 
-// eslint: https://eslint.org/docs/latest/
-// typescript-eslint: https://typescript-eslint.io/getting-started/
-
 import eslint from "@eslint/js";
 import globals from "globals";
 import tseslint from "typescript-eslint";

--- a/packages/react/eslint.config.js
+++ b/packages/react/eslint.config.js
@@ -1,8 +1,5 @@
 // @ts-check
 
-// eslint: https://eslint.org/docs/latest/
-// typescript-eslint: https://typescript-eslint.io/getting-started/
-
 import eslint from "@eslint/js";
 import globals from "globals";
 import tseslint from "typescript-eslint";

--- a/packages/ui/eslint.config.js
+++ b/packages/ui/eslint.config.js
@@ -1,8 +1,5 @@
 // @ts-check
 
-// eslint: https://eslint.org/docs/latest/
-// typescript-eslint: https://typescript-eslint.io/getting-started/
-
 import eslint from "@eslint/js";
 import globals from "globals";
 import tseslint from "typescript-eslint";

--- a/src/canvas/App.tsx
+++ b/src/canvas/App.tsx
@@ -1,14 +1,14 @@
 import { useState } from "react";
-import { CanvasWidgetState } from "../types/frontend";
-import { WidgetSettings } from "../types/backend";
-import { emitUpdateSettingsToManager } from "../events";
-import WidgetContainer from "./components/WidgetContainer";
-import useRenderWidgetListener from "./hooks/useRenderWidgetListener";
-import useRemoveWidgetsListener from "./hooks/useRemoveWidgetsListener";
-import useShowToastListener from "./hooks/useShowToastListener";
+import { CanvasWidgetState } from "@/types/frontend";
+import { WidgetSettings } from "@/types/backend";
+import { emitUpdateSettingsToManager } from "@/events";
+import WidgetContainer from "@/canvas/components/WidgetContainer";
+import useRenderWidgetListener from "@/canvas/hooks/useRenderWidgetListener";
+import useRemoveWidgetsListener from "@/canvas/hooks/useRemoveWidgetsListener";
+import useShowToastListener from "@/canvas/hooks/useShowToastListener";
 import { Toaster } from "sonner";
 import { Theme } from "@radix-ui/themes";
-import useAppearanceListener from "./hooks/useAppearanceListener";
+import useAppearanceListener from "@/canvas/hooks/useAppearanceListener";
 
 /**
  * The main component of the canvas window.

--- a/src/canvas/components/WidgetContainer.tsx
+++ b/src/canvas/components/WidgetContainer.tsx
@@ -1,12 +1,12 @@
 import { PropsWithChildren, RefObject, useRef } from "react";
 import Draggable, { DraggableData, DraggableEvent } from "react-draggable";
 import { ErrorBoundary } from "react-error-boundary";
-import ErrorDisplay from "./ErrorDisplay";
-import { grabErrorInfo } from "../utils";
-import { WidgetSettings } from "../../types/backend";
+import ErrorDisplay from "@/canvas/components/ErrorDisplay";
+import { grabErrorInfo } from "@/canvas/utils";
+import { WidgetSettings } from "@/types/backend";
 import { LuGripVertical } from "react-icons/lu";
 import { Box } from "@radix-ui/themes";
-import { Widget } from "../../types/frontend";
+import { Widget } from "@/types/frontend";
 
 export interface WidgetContainerProps {
   /** ID of the widget. */

--- a/src/canvas/hooks/useAppearanceListener.ts
+++ b/src/canvas/hooks/useAppearanceListener.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
-import { Appearance } from "../../types/backend";
-import { listenToSwitchAppearance } from "../../events";
+import { Appearance } from "@/types/backend";
+import { listenToSwitchAppearance } from "@/events";
 
 /**
  * Handle the theme appearance of the canvas.

--- a/src/canvas/hooks/useRemoveWidgetsListener.tsx
+++ b/src/canvas/hooks/useRemoveWidgetsListener.tsx
@@ -1,6 +1,6 @@
 import { Dispatch, SetStateAction, useEffect } from "react";
-import { listenToRemoveWidgets } from "../../events";
-import { CanvasWidgetState } from "../../types/frontend";
+import { listenToRemoveWidgets } from "@/events";
+import { CanvasWidgetState } from "@/types/frontend";
 
 /**
  * Listen and react to the "remove-widgets" event.

--- a/src/canvas/hooks/useRenderWidgetListener.tsx
+++ b/src/canvas/hooks/useRenderWidgetListener.tsx
@@ -1,10 +1,10 @@
 import { Dispatch, SetStateAction, useEffect } from "react";
-import { listenToRenderWidget } from "../../events";
-import { CanvasWidgetState, WidgetModule } from "../../types/frontend";
-import { WidgetSettings } from "../../types/backend";
-import { invokeBundleWidget } from "../../commands";
-import ErrorDisplay from "../components/ErrorDisplay";
-import { grabErrorInfo } from "../utils";
+import { listenToRenderWidget } from "@/events";
+import { CanvasWidgetState, WidgetModule } from "@/types/frontend";
+import { WidgetSettings } from "@/types/backend";
+import { invokeBundleWidget } from "@/commands";
+import ErrorDisplay from "@/canvas/components/ErrorDisplay";
+import { grabErrorInfo } from "@/canvas/utils";
 
 // The default width and height of a widget container, used when the widget module
 // fails to be loaded correctly

--- a/src/canvas/hooks/useShowToastListener.tsx
+++ b/src/canvas/hooks/useShowToastListener.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { listenToShowToast } from "../../events";
+import { listenToShowToast } from "@/events";
 import { toast } from "sonner";
 
 /**

--- a/src/canvas/main.tsx
+++ b/src/canvas/main.tsx
@@ -1,6 +1,6 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import App from "./App";
+import App from "@/canvas/App";
 import "@radix-ui/themes/styles.css";
 
 createRoot(document.getElementById("root")!).render(

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -6,7 +6,7 @@
  */
 
 import { invoke } from "@tauri-apps/api/core";
-import { Settings, WidgetCollection } from "./types/backend";
+import { Settings, WidgetCollection } from "@/types/backend";
 
 /**
  * Invoke the `bundle_widget` command.

--- a/src/eslint.config.js
+++ b/src/eslint.config.js
@@ -1,8 +1,5 @@
 // @ts-check
 
-// eslint: https://eslint.org/docs/latest/
-// typescript-eslint: https://typescript-eslint.io/getting-started/
-
 import eslint from "@eslint/js";
 import globals from "globals";
 import tseslint from "typescript-eslint";
@@ -47,12 +44,21 @@ export default tseslint.config(
       ],
       // Sort within multiple imports from the same module; sorting across modules is
       // disabled because it cannot be autofixed and sorts by declarations instead of
-      // import specifiers; TODO: complement with eslint-plugin-import when it supports
-      // eslint flat configuration
+      // import specifiers; TODO: complement with eslint-plugin-import
       "sort-imports": [
         "error",
         {
           ignoreDeclarationSort: true,
+        },
+      ],
+      // Allow only absolute path from `@` which is the project root
+      "no-restricted-imports": "off",
+      "@typescript-eslint/no-restricted-imports": [
+        "error",
+        {
+          patterns: [
+            { group: [".*"], message: "Use absolute path imports from `@`" },
+          ],
         },
       ],
     },

--- a/src/events.ts
+++ b/src/events.ts
@@ -10,8 +10,8 @@ import {
   RemoveWidgetsPayload,
   RenderWidgetPayload,
   UpdateSettingsPayload,
-} from "./types/frontend";
-import { Appearance, ShowToastPayload } from "./types/backend";
+} from "@/types/frontend";
+import { Appearance, ShowToastPayload } from "@/types/backend";
 
 /**
  * Emit the "render-widget" event to the canvas window.

--- a/src/manager/App.tsx
+++ b/src/manager/App.tsx
@@ -1,15 +1,15 @@
 import { useState } from "react";
-import WidgetsTab from "./tabs/WidgetsTab";
-import SettingsTab from "./tabs/SettingsTab";
-import AboutTab from "./tabs/AboutTab";
-import useExitAppListener from "./hooks/useExitAppListener";
-import useToggleShortcut from "./hooks/useToggleShortcut";
-import useManagerWidgetStates from "./hooks/useManagerWidgetStates";
-import useUpdateSettingsListener from "./hooks/useUpdateSettingsListener";
-import { Settings } from "../types/backend";
+import WidgetsTab from "@/manager/tabs/WidgetsTab";
+import SettingsTab from "@/manager/tabs/SettingsTab";
+import AboutTab from "@/manager/tabs/AboutTab";
+import useExitAppListener from "@/manager/hooks/useExitAppListener";
+import useToggleShortcut from "@/manager/hooks/useToggleShortcut";
+import useManagerWidgetStates from "@/manager/hooks/useManagerWidgetStates";
+import useUpdateSettingsListener from "@/manager/hooks/useUpdateSettingsListener";
+import { Settings } from "@/types/backend";
 import { Box, Tabs, Theme } from "@radix-ui/themes";
-import ManagerToaster from "./components/ManagerToaster";
-import AppearanceToggler from "./components/AppearanceToggler";
+import ManagerToaster from "@/manager/components/ManagerToaster";
+import AppearanceToggler from "@/manager/components/AppearanceToggler";
 
 export interface ManagerAppProps {
   /** The initial settings read from the previously saved setting file. */

--- a/src/manager/components/AppearanceToggler.tsx
+++ b/src/manager/components/AppearanceToggler.tsx
@@ -1,8 +1,8 @@
 import { Box, IconButton, Tooltip } from "@radix-ui/themes";
-import { Appearance } from "../../types/backend";
+import { Appearance } from "@/types/backend";
 import { MdOutlineDarkMode, MdOutlineLightMode } from "react-icons/md";
 import { Dispatch, SetStateAction } from "react";
-import { emitSwitchAppearanceToCanvas } from "../../events";
+import { emitSwitchAppearanceToCanvas } from "@/events";
 
 export interface AppearanceTogglerProps {
   /** Theme appearance. */

--- a/src/manager/components/ManagerToaster.tsx
+++ b/src/manager/components/ManagerToaster.tsx
@@ -1,5 +1,5 @@
 import { Toaster } from "sonner";
-import { Appearance } from "../../types/backend";
+import { Appearance } from "@/types/backend";
 
 export interface ManagerToasterProps {
   /** The theme appearance. */

--- a/src/manager/components/SettingToggleShortcut.tsx
+++ b/src/manager/components/SettingToggleShortcut.tsx
@@ -10,9 +10,9 @@ import {
   Text,
 } from "@radix-ui/themes";
 import { Dispatch, SetStateAction, useEffect, useState } from "react";
-import Shortcut from "./Shortcut";
+import Shortcut from "@/manager/components/Shortcut";
 import { FaEdit } from "react-icons/fa";
-import useKeyboardListener from "../hooks/useKeyboardListener";
+import useKeyboardListener from "@/manager/hooks/useKeyboardListener";
 
 export interface SettingToggleShortcutProps {
   /** Setter for the toggle shortcut state. */

--- a/src/manager/components/WidgetContent.tsx
+++ b/src/manager/components/WidgetContent.tsx
@@ -8,15 +8,15 @@ import {
   Text,
 } from "@radix-ui/themes";
 import { LuFolderOpen, LuRepeat } from "react-icons/lu";
-import { invokeOpenInWidgetsDir } from "../../commands";
-import { Result, WidgetConfig, WidgetSettings } from "../../types/backend";
-import { emitRenderWidgetToCanvas } from "../../events";
+import { invokeOpenInWidgetsDir } from "@/commands";
+import { Result, WidgetConfig, WidgetSettings } from "@/types/backend";
+import { emitRenderWidgetToCanvas } from "@/events";
 import { Dispatch, SetStateAction } from "react";
-import { ManagerWidgetState } from "../../types/frontend";
-import WidgetContentHeading from "./WidgetContentHeading";
+import { ManagerWidgetState } from "@/types/frontend";
+import WidgetContentHeading from "@/manager/components/WidgetContentHeading";
 import { toast } from "sonner";
-import WidgetContentConfigList from "./WidgetContentConfigList";
-import WidgetContentSettingsList from "./WidgetContentSettingsList";
+import WidgetContentConfigList from "@/manager/components/WidgetContentConfigList";
+import WidgetContentSettingsList from "@/manager/components/WidgetContentSettingsList";
 
 export interface WidgetContentProps {
   /** The index of the widget in the collection. */

--- a/src/manager/components/WidgetContentConfigList.tsx
+++ b/src/manager/components/WidgetContentConfigList.tsx
@@ -1,8 +1,8 @@
 import { Code, DataList, Flex, IconButton, Tooltip } from "@radix-ui/themes";
-import { WidgetConfig } from "../../types/backend";
-import WidgetDependencies from "./WidgetDependencies";
+import { WidgetConfig } from "@/types/backend";
+import WidgetDependencies from "@/manager/components/WidgetDependencies";
 import { MdOpenInNew } from "react-icons/md";
-import { invokeOpenInWidgetsDir } from "../../commands";
+import { invokeOpenInWidgetsDir } from "@/commands";
 
 export interface WidgetContentConfigListProps {
   /** The widget ID. */

--- a/src/manager/components/WidgetContentSettingsList.tsx
+++ b/src/manager/components/WidgetContentSettingsList.tsx
@@ -1,9 +1,9 @@
 import { Dispatch, SetStateAction } from "react";
-import { WidgetSettings } from "../../types/backend";
-import { ManagerWidgetState } from "../../types/frontend";
-import { emitRenderWidgetToCanvas } from "../../events";
+import { WidgetSettings } from "@/types/backend";
+import { ManagerWidgetState } from "@/types/frontend";
+import { emitRenderWidgetToCanvas } from "@/events";
 import { DataList, Flex } from "@radix-ui/themes";
-import NumberInput from "./NumberInput";
+import NumberInput from "@/manager/components/NumberInput";
 import { FaTimes } from "react-icons/fa";
 
 export interface WidgetContentSettingListProps {

--- a/src/manager/components/WidgetTrigger.tsx
+++ b/src/manager/components/WidgetTrigger.tsx
@@ -1,5 +1,5 @@
 import { Badge, Box, Flex, Tabs, Text } from "@radix-ui/themes";
-import { Result, WidgetConfig } from "../../types/backend";
+import { Result, WidgetConfig } from "@/types/backend";
 
 export interface WidgetTriggerProps {
   /** The index of the widget in the collection. */

--- a/src/manager/hooks/useExitAppListener.ts
+++ b/src/manager/hooks/useExitAppListener.ts
@@ -1,8 +1,8 @@
 import { useEffect } from "react";
-import { listenToExitApp } from "../../events";
-import { invokeExitApp } from "../../commands";
-import { ManagerWidgetState } from "../../types/frontend";
-import { Appearance } from "../../types/backend";
+import { listenToExitApp } from "@/events";
+import { invokeExitApp } from "@/commands";
+import { ManagerWidgetState } from "@/types/frontend";
+import { Appearance } from "@/types/backend";
 
 /**
  * Listen and react to the "exit-app" event.

--- a/src/manager/hooks/useManagerWidgetStates.ts
+++ b/src/manager/hooks/useManagerWidgetStates.ts
@@ -1,11 +1,8 @@
 import { Dispatch, SetStateAction, useEffect, useState } from "react";
-import { ManagerWidgetState } from "../../types/frontend";
-import { WidgetSettings } from "../../types/backend";
-import { invokeRescanWidgets } from "../../commands";
-import {
-  emitRemoveWidgetsToCanvas,
-  emitRenderWidgetToCanvas,
-} from "../../events";
+import { ManagerWidgetState } from "@/types/frontend";
+import { WidgetSettings } from "@/types/backend";
+import { invokeRescanWidgets } from "@/commands";
+import { emitRemoveWidgetsToCanvas, emitRenderWidgetToCanvas } from "@/events";
 
 export interface UseManagerWidgetStatesOutput {
   /** The manager widget states. */

--- a/src/manager/hooks/useToggleShortcut.ts
+++ b/src/manager/hooks/useToggleShortcut.ts
@@ -1,5 +1,5 @@
 import { Dispatch, SetStateAction, useEffect, useState } from "react";
-import { invokeUpdateToggleShortcut } from "../../commands";
+import { invokeUpdateToggleShortcut } from "@/commands";
 
 export interface UseToggleShortcutOutput {
   /** The current toggle shortcut. */

--- a/src/manager/hooks/useUpdateSettingsListener.ts
+++ b/src/manager/hooks/useUpdateSettingsListener.ts
@@ -1,6 +1,6 @@
 import { Dispatch, SetStateAction, useEffect } from "react";
-import { listenToUpdateSettings } from "../../events";
-import { ManagerWidgetState } from "../../types/frontend";
+import { listenToUpdateSettings } from "@/events";
+import { ManagerWidgetState } from "@/types/frontend";
 
 /**
  * Listen and react to the "update-setting" event.

--- a/src/manager/main.tsx
+++ b/src/manager/main.tsx
@@ -1,10 +1,10 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import { invokeLoadSettings } from "../commands";
-import { emitSwitchAppearanceToCanvas } from "../events";
-import App from "./App";
+import { invokeLoadSettings } from "@/commands";
+import { emitSwitchAppearanceToCanvas } from "@/events";
+import App from "@/manager/App";
 import "@radix-ui/themes/styles.css";
-import "../custom.css";
+import "@/custom.css";
 
 invokeLoadSettings()
   .then((settings) => {

--- a/src/manager/tabs/AboutTab.tsx
+++ b/src/manager/tabs/AboutTab.tsx
@@ -1,5 +1,5 @@
 import { Avatar, DataList, Flex, Heading, Text } from "@radix-ui/themes";
-import ExternalCopyLink from "../components/ExternalCopyLink";
+import ExternalCopyLink from "@/manager/components/ExternalCopyLink";
 import Logo from "/deskulpt.svg";
 
 /**

--- a/src/manager/tabs/SettingsTab.tsx
+++ b/src/manager/tabs/SettingsTab.tsx
@@ -1,7 +1,7 @@
 import { Dispatch, SetStateAction } from "react";
 import { DataList, Flex } from "@radix-ui/themes";
-import SettingToggleShortcut from "../components/SettingToggleShortcut";
-import Shortcut from "../components/Shortcut";
+import SettingToggleShortcut from "@/manager/components/SettingToggleShortcut";
+import Shortcut from "@/manager/components/Shortcut";
 
 export interface SettingsTabProps {
   /** The current toggle shortcut. */

--- a/src/manager/tabs/WidgetsTab.tsx
+++ b/src/manager/tabs/WidgetsTab.tsx
@@ -1,13 +1,13 @@
 import { Dispatch, SetStateAction } from "react";
 import { LuFileScan, LuFolderOpen, LuRepeat } from "react-icons/lu";
-import { invokeOpenInWidgetsDir } from "../../commands";
+import { invokeOpenInWidgetsDir } from "@/commands";
 import { Flex, ScrollArea, Tabs } from "@radix-ui/themes";
 import { toast } from "sonner";
-import { ManagerWidgetState } from "../../types/frontend";
-import WidgetTrigger from "../components/WidgetTrigger";
-import WidgetContent from "../components/WidgetContent";
-import FloatButton from "../components/FloatButton";
-import { emitRenderWidgetToCanvas } from "../../events";
+import { ManagerWidgetState } from "@/types/frontend";
+import WidgetTrigger from "@/manager/components/WidgetTrigger";
+import WidgetContent from "@/manager/components/WidgetContent";
+import FloatButton from "@/manager/components/FloatButton";
+import { emitRenderWidgetToCanvas } from "@/events";
 
 export interface WidgetsTabProps {
   /** The manager widget states. */

--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -5,6 +5,7 @@
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
+    "paths": { "@/*": ["./*"] },
 
     /* Bundler mode */
     "moduleResolution": "bundler",

--- a/src/types/frontend.ts
+++ b/src/types/frontend.ts
@@ -4,7 +4,7 @@
  */
 
 import { ReactNode } from "react";
-import { Result, WidgetConfig, WidgetSettings } from "./backend";
+import { Result, WidgetConfig, WidgetSettings } from "@/types/backend";
 
 /**
  * The user-defined widget interface.

--- a/src/vite.config.ts
+++ b/src/vite.config.ts
@@ -3,6 +3,11 @@ import { resolve } from "path";
 import react from "@vitejs/plugin-react";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@": __dirname,
+    },
+  },
   plugins: [
     react({
       jsxImportSource: "@emotion/react",


### PR DESCRIPTION
Prefer `@/...` imports over relative imports. ESlint will raise errors against relative imports since this PR. The workspace VSCode settings would prefer `@/...` for auto imports as well.