### PR TITLE
refactor: avoid using macro where unnecessary

### DIFF
--- a/crates/deskulpt-core/src/states/canvas_click_through.rs
+++ b/crates/deskulpt-core/src/states/canvas_click_through.rs
@@ -17,82 +17,69 @@ use crate::events::{EventsExt, ShowToastPayload};
 struct CanvasClickThroughState<R: Runtime>(Mutex<(bool, Option<MenuItem<R>>)>);
 
 /// Extension trait for operations on canvas click-through state.
-pub trait StatesExtCanvasClickThrough<R: Runtime> {
+pub trait StatesExtCanvasClickThrough<R: Runtime>: Manager<R> + EventsExt<R> {
     /// Initialize state management for whether the canvas is click-through.
     ///
     /// The canvas is click-through by default.
-    fn manage_canvas_click_through(&self);
+    fn manage_canvas_click_through(&self) {
+        self.manage(CanvasClickThroughState::<R>(Mutex::new((true, None))));
+    }
 
     /// Set the menu item for toggling the canvas click-through state.
-    fn set_canvas_click_through_menu_item(&self, menu_item: &MenuItem<R>);
+    fn set_canvas_click_through_menu_item(&self, menu_item: &MenuItem<R>) {
+        let state = self.state::<CanvasClickThroughState<R>>();
+        let mut canvas_click_through = state.0.lock().unwrap();
+
+        // Cloning works because menu items are behind shared references
+        canvas_click_through.1 = Some(menu_item.clone());
+    }
 
     /// Toggle the click-through state of the canvas window.
     ///
     /// This will also update the menu item text and show a toast message on the
     /// canvas if possible.
-    fn toggle_canvas_click_through(&self) -> Result<()>;
-}
+    fn toggle_canvas_click_through(&self) -> Result<()> {
+        let canvas = self
+            .get_webview_window("canvas")
+            .expect("Canvas window not found");
 
-/// Shared implementation of [`StatesExtCanvasClickThrough`].
-macro_rules! shared_impl {
-    ($app: ty) => {
-        impl<R: Runtime> StatesExtCanvasClickThrough<R> for $app {
-            fn manage_canvas_click_through(&self) {
-                self.manage(CanvasClickThroughState::<R>(Mutex::new((true, None))));
+        let state = self.state::<CanvasClickThroughState<R>>();
+        let mut canvas_click_through = state.0.lock().unwrap();
+        let prev_click_through = canvas_click_through.0;
+        canvas.set_ignore_cursor_events(!prev_click_through)?;
+        canvas_click_through.0 = !prev_click_through;
+
+        let (menu_item_text, toast_message) = if prev_click_through {
+            // If the canvas is toggled to not click-through, try to regain
+            // focus to avoid flickering on the first click
+            if let Err(e) = canvas.set_focus() {
+                eprintln!("Failed to gain focus on canvas: {}", e);
             }
+            ("Sink", "Canvas floated.")
+        } else {
+            ("Float", "Canvas sunk.")
+        };
 
-            fn set_canvas_click_through_menu_item(&self, menu_item: &MenuItem<R>) {
-                let state = self.state::<CanvasClickThroughState<R>>();
-                let mut canvas_click_through = state.0.lock().unwrap();
-
-                // Cloning works because menu items are behind shared references
-                canvas_click_through.1 = Some(menu_item.clone());
-            }
-
-            fn toggle_canvas_click_through(&self) -> Result<()> {
-                let canvas = self
-                    .get_webview_window("canvas")
-                    .expect("Canvas window not found");
-
-                let state = self.state::<CanvasClickThroughState<R>>();
-                let mut canvas_click_through = state.0.lock().unwrap();
-                let prev_click_through = canvas_click_through.0;
-                canvas.set_ignore_cursor_events(!prev_click_through)?;
-                canvas_click_through.0 = !prev_click_through;
-
-                let (menu_item_text, toast_message) = if prev_click_through {
-                    // If the canvas is toggled to not click-through, try to regain
-                    // focus to avoid flickering on the first click
-                    if let Err(e) = canvas.set_focus() {
-                        eprintln!("Failed to gain focus on canvas: {}", e);
-                    }
-                    ("Sink", "Canvas floated.")
-                } else {
-                    ("Float", "Canvas sunk.")
-                };
-
-                // Update menu item text if it exists
-                if let Some(menu_item) = canvas_click_through.1.as_ref() {
-                    if let Err(e) = menu_item.set_text(menu_item_text) {
-                        eprintln!(
-                            "Failed to update menu item for toggling canvas click-through: {}",
-                            e
-                        );
-                    }
-                }
-
-                // Show a toast message on the canvas
-                if let Err(e) = self
-                    .emit_show_toast_to_canvas(ShowToastPayload::Success(toast_message.to_string()))
-                {
-                    eprintln!("Failed to emit show-toast to canvas: {}", e);
-                }
-
-                Ok(())
+        // Update menu item text if it exists
+        if let Some(menu_item) = canvas_click_through.1.as_ref() {
+            if let Err(e) = menu_item.set_text(menu_item_text) {
+                eprintln!(
+                    "Failed to update menu item for toggling canvas click-through: {}",
+                    e
+                );
             }
         }
-    };
+
+        // Show a toast message on the canvas
+        if let Err(e) =
+            self.emit_show_toast_to_canvas(ShowToastPayload::Success(toast_message.to_string()))
+        {
+            eprintln!("Failed to emit show-toast to canvas: {}", e);
+        }
+
+        Ok(())
+    }
 }
 
-shared_impl!(App<R>);
-shared_impl!(AppHandle<R>);
+impl<R: Runtime> StatesExtCanvasClickThrough<R> for App<R> {}
+impl<R: Runtime> StatesExtCanvasClickThrough<R> for AppHandle<R> {}

--- a/crates/deskulpt-core/src/tray.rs
+++ b/crates/deskulpt-core/src/tray.rs
@@ -6,7 +6,7 @@ use anyhow::Result;
 use tauri::image::Image;
 use tauri::menu::{MenuBuilder, MenuEvent, MenuItemBuilder};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIcon, TrayIconBuilder, TrayIconEvent};
-use tauri::{App, AppHandle, Runtime};
+use tauri::{App, AppHandle, Manager, Runtime};
 use tokio::time::sleep;
 
 use crate::events::EventsExt;
@@ -14,49 +14,42 @@ use crate::states::StatesExtCanvasClickThrough;
 use crate::window::WindowExt;
 
 /// Extention trait for system tray-related operations.
-pub trait TrayExt {
+pub trait TrayExt<R: Runtime>: Manager<R> + StatesExtCanvasClickThrough<R> {
     /// Create the system tray.
-    fn create_tray(&self, icon: Image) -> Result<()>;
+    fn create_tray(&self, icon: Image) -> Result<()>
+    where
+        Self: Sized,
+    {
+        // Store the menu item for toggling canvas click-through
+        let menu_item_toggle = MenuItemBuilder::with_id("tray-toggle", "Float").build(self)?;
+        self.set_canvas_click_through_menu_item(&menu_item_toggle);
+
+        // Build the system tray menu
+        let tray_menu = MenuBuilder::new(self)
+            .items(&[
+                &menu_item_toggle,
+                &MenuItemBuilder::with_id("tray-manage", "Manage").build(self)?,
+                &MenuItemBuilder::with_id("tray-exit", "Exit").build(self)?,
+            ])
+            .build()?;
+
+        // Build the system tray icon
+        TrayIconBuilder::with_id("tray")
+            .icon(icon)
+            .icon_as_template(true)
+            .show_menu_on_left_click(false)
+            .tooltip("Deskulpt")
+            .menu(&tray_menu)
+            .on_menu_event(on_menu_event)
+            .on_tray_icon_event(on_tray_icon_event)
+            .build(self)?;
+
+        Ok(())
+    }
 }
 
-/// Shared implementation of [`TrayExt`].
-macro_rules! shared_impl {
-    ($app: ty) => {
-        impl<R: Runtime> TrayExt for $app {
-            fn create_tray(&self, icon: Image) -> Result<()> {
-                // Store the menu item for toggling canvas click-through
-                let menu_item_toggle =
-                    MenuItemBuilder::with_id("tray-toggle", "Float").build(self)?;
-                self.set_canvas_click_through_menu_item(&menu_item_toggle);
-
-                // Build the system tray menu
-                let tray_menu = MenuBuilder::new(self)
-                    .items(&[
-                        &menu_item_toggle,
-                        &MenuItemBuilder::with_id("tray-manage", "Manage").build(self)?,
-                        &MenuItemBuilder::with_id("tray-exit", "Exit").build(self)?,
-                    ])
-                    .build()?;
-
-                // Build the system tray icon
-                TrayIconBuilder::with_id("tray")
-                    .icon(icon)
-                    .icon_as_template(true)
-                    .show_menu_on_left_click(false)
-                    .tooltip("Deskulpt")
-                    .menu(&tray_menu)
-                    .on_menu_event(on_menu_event)
-                    .on_tray_icon_event(on_tray_icon_event)
-                    .build(self)?;
-
-                Ok(())
-            }
-        }
-    };
-}
-
-shared_impl!(App<R>);
-shared_impl!(AppHandle<R>);
+impl<R: Runtime> TrayExt<R> for App<R> {}
+impl<R: Runtime> TrayExt<R> for AppHandle<R> {}
 
 /// Handler for system tray menu events.
 ///


### PR DESCRIPTION
Extracted from #370.

We should avoid using macros where unnecessary. It will weaken the formatter and editor completion.