### PR TITLE
maint: more linter rules especially for react

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -6,12 +6,18 @@
     "src/generated/**",
     "**/website/**"
   ],
-  "plugins": ["react/jsx-runtime", "unicorn", "typescript", "oxc"],
+  "plugins": ["import", "oxc", "react", "typescript", "unicorn"],
   "categories": {
     "correctness": "error",
     "suspicious": "error",
     "perf": "warn",
     "pedantic": "warn"
+  },
+  "rules": {
+    "sort-imports": ["error", { "ignoreDeclarationSort": true }],
+    "import/max-dependencies": "off",
+    "react/react-in-jsx-scope": "off",
+    "react/exhaustive-deps": "warn"
   },
   "overrides": [
     {

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -17,7 +17,7 @@
     "sort-imports": ["error", { "ignoreDeclarationSort": true }],
     "import/max-dependencies": "off",
     "react/react-in-jsx-scope": "off",
-    "react/exhaustive-deps": "warn"
+    "react/exhaustive-deps": "error"
   },
   "overrides": [
     {

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,4 +1,4 @@
-import { css, keyframes } from "@emotion/react";
+export { css, keyframes } from "@emotion/react";
 
 /**
  * Layout
@@ -9,14 +9,14 @@ import { css, keyframes } from "@emotion/react";
  *   scenario of widgets which have fixed dimensions
  * - `Section`: denotes a section of page content; not useful for the same reason
  */
-import { Box, Flex, Grid } from "@radix-ui/themes";
+export { Box, Flex, Grid } from "@radix-ui/themes";
 
 /**
  * Typography
  *
  * All typography components are included.
  */
-import {
+export {
   Blockquote,
   Code,
   Em,
@@ -44,7 +44,7 @@ import {
  * - `Skeleton`: unnecessary complexity for a widget
  * - `TabNav`: mostly for navigating between pages, not useful for widgets
  */
-import {
+export {
   AspectRatio,
   Avatar,
   Badge,
@@ -72,46 +72,3 @@ import {
   TextField,
   Tooltip,
 } from "@radix-ui/themes";
-
-export {
-  css,
-  keyframes,
-  Box,
-  Flex,
-  Grid,
-  Text,
-  Heading,
-  Blockquote,
-  Code,
-  Em,
-  Kbd,
-  Link,
-  Quote,
-  Strong,
-  AspectRatio,
-  Avatar,
-  Badge,
-  Button,
-  Checkbox,
-  CheckboxGroup,
-  ContextMenu,
-  DataList,
-  DropdownMenu,
-  IconButton,
-  Popover,
-  Progress,
-  Radio,
-  RadioGroup,
-  ScrollArea,
-  SegmentedControl,
-  Select,
-  Separator,
-  Slider,
-  Spinner,
-  Switch,
-  Table,
-  Tabs,
-  TextArea,
-  TextField,
-  Tooltip,
-};

--- a/src/canvas/hooks/useRemoveWidgetsListener.tsx
+++ b/src/canvas/hooks/useRemoveWidgetsListener.tsx
@@ -46,5 +46,5 @@ export default function useRemoveWidgetsListener(
     return () => {
       unlisten.then((f) => f()).catch(console.error);
     };
-  }, [canvasWidgetStates]);
+  }, [canvasWidgetStates, setCanvasWidgetStates]);
 }

--- a/src/manager/App.tsx
+++ b/src/manager/App.tsx
@@ -21,9 +21,7 @@ export default function App() {
     window.__DESKULPT_MANAGER_INTERNALS__.initialSettings.toggleShortcut,
   );
   const { managerWidgetStates, setManagerWidgetStates, rescanAndRender } =
-    useManagerWidgetStates(
-      window.__DESKULPT_MANAGER_INTERNALS__.initialSettings.widgetSettingsMap,
-    );
+    useManagerWidgetStates();
 
   useExitAppListener(toggleShortcut, appearance, managerWidgetStates);
   useUpdateSettingsListener(setManagerWidgetStates);

--- a/src/manager/components/NumberInput.tsx
+++ b/src/manager/components/NumberInput.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useEffect } from "react";
+import { ChangeEvent } from "react";
 
 export interface NumberInputProps {
   /** The controlled number input value. */
@@ -32,10 +32,6 @@ export default function NumberInput({
   max,
   width,
 }: NumberInputProps) {
-  useEffect(() => {
-    onChange(value);
-  }, [value]);
-
   function handleChange(event: ChangeEvent<HTMLInputElement>) {
     if (event.target.value === "") {
       onChange(min ?? 0);

--- a/src/manager/components/SettingToggleShortcut.tsx
+++ b/src/manager/components/SettingToggleShortcut.tsx
@@ -60,13 +60,13 @@ export default function SettingToggleShortcut({
     if (disableShortcut) {
       cleanup();
     }
-  }, [disableShortcut]);
+  }, [disableShortcut, cleanup]);
 
   // Cleanup and reset states when popover is opened/closed
   useEffect(() => {
     setDisableShortcut(false);
     cleanup();
-  }, [popoverOpen]);
+  }, [popoverOpen, cleanup]);
 
   return (
     <Popover.Root
@@ -97,9 +97,10 @@ export default function SettingToggleShortcut({
           {/* Introduction */}
           <Blockquote size="1" color="gray">
             The toggle shortcut is used for toggling the floating/sinking state
-            of the canvas, equivalent to the "Float/Sink" option in the tray
-            menu. Widgets are not interactable when the canvas is floated, and
-            the desktop is not interactable when the canvas is sunk.
+            of the canvas, equivalent to the &quot;Float/Sink&quot; option in
+            the tray menu. Widgets are not interactable when the canvas is
+            floated, and the desktop is not interactable when the canvas is
+            sunk.
           </Blockquote>
           {/* Decision whether to disable the shortcut */}
           <Text size="1">

--- a/src/manager/components/Shortcut.tsx
+++ b/src/manager/components/Shortcut.tsx
@@ -30,7 +30,7 @@ export default function Shortcut({
       {keys.map(
         (key, index) =>
           index !== 0 && (
-            <Fragment key={index}>
+            <Fragment key={key}>
               <Text size={size}>+</Text>
               <Kbd size={size}>{key}</Kbd>
             </Fragment>

--- a/src/manager/components/WidgetDependencies.tsx
+++ b/src/manager/components/WidgetDependencies.tsx
@@ -41,8 +41,8 @@ export default function WidgetDependencies({
           <Popover.Content size="1">
             <ScrollArea scrollbars="vertical">
               <Flex direction="column" maxHeight="100px" pr="4" gap="1">
-                {dependenciesArray.map(([name, version], index) => (
-                  <Flex key={index} gap="4" align="center">
+                {dependenciesArray.map(([name, version]) => (
+                  <Flex key={name} gap="4" align="center">
                     <Link
                       size="1"
                       href={`https://www.npmjs.com/package/${name}`}

--- a/src/manager/hooks/useUpdateSettingsListener.ts
+++ b/src/manager/hooks/useUpdateSettingsListener.ts
@@ -31,5 +31,5 @@ export default function useUpdateSettingListener(
     return () => {
       unlisten.then((f) => f()).catch(console.error);
     };
-  }, []);
+  }, [setManagerWidgetStates]);
 }


### PR DESCRIPTION
Extracted from #370.

`react/jsx-runtime` was a wrong specification. The correct way to do in oxlint is `react` with `react-in-jsx-scope` disabled.