### PR TITLE
chore: open detached and with shell-execute on windows

### DIFF
--- a/crates/deskulpt-core/Cargo.toml
+++ b/crates/deskulpt-core/Cargo.toml
@@ -14,7 +14,7 @@ anyhow                       = { workspace = true }
 bincode                      = { workspace = true }
 dunce                        = { workspace = true }
 once_cell                    = { workspace = true }
-open                         = { workspace = true }
+open                         = { workspace = true, features = ["shellexecute-on-windows"] }
 oxc                          = { workspace = true }
 path-clean                   = { workspace = true }
 rolldown                     = { workspace = true }

--- a/crates/deskulpt-core/src/commands/open_in_widgets_dir.rs
+++ b/crates/deskulpt-core/src/commands/open_in_widgets_dir.rs
@@ -20,7 +20,7 @@ pub async fn open_in_widgets_dir<R: Runtime>(
 ) -> CmdResult<()> {
     let mut open_path = app_handle.widgets_dir().to_path_buf();
     open_path.extend(components);
-    open::that(open_path)?;
+    open::that_detached(open_path)?;
 
     Ok(())
 }


### PR DESCRIPTION
Extracted from #370.

The `that_detached` is because `that` does not seem to work if I specify another program (I mean, `with_detached` versus `with` in this case), at least on Windows. The detached version does work. Also shell-execute feature is needed.