### PR TITLE
refactor: pathext create dir whenever accessed b/c users can delete them halfway

### DIFF
--- a/crates/deskulpt-core/src/commands/bundle_widget.rs
+++ b/crates/deskulpt-core/src/commands/bundle_widget.rs
@@ -11,6 +11,7 @@ use crate::states::StatesExtWidgetConfigMap;
 ///
 /// ### Errors
 ///
+/// - Failed to access the widgets directory.
 /// - Widget ID does not exist in the configuration map.
 /// - Widget has a configuration error.
 /// - Error bundling the widget.
@@ -21,7 +22,7 @@ pub async fn bundle_widget<R: Runtime>(
     base_url: String,
     apis_blob_url: String,
 ) -> CmdResult<String> {
-    let widgets_dir = app_handle.widgets_dir();
+    let widgets_dir = app_handle.widgets_dir()?;
 
     let mut bundler = app_handle.with_widget_config_map(|config_map| {
         match config_map

--- a/crates/deskulpt-core/src/commands/exit_app.rs
+++ b/crates/deskulpt-core/src/commands/exit_app.rs
@@ -1,6 +1,5 @@
 use tauri::{command, AppHandle, Runtime};
 
-use super::error::CmdResult;
 use crate::path::PathExt;
 use crate::settings::Settings;
 
@@ -10,12 +9,14 @@ use crate::settings::Settings;
 /// application in the end. Prior to exiting, it will try to dump the settings
 /// for persistence, but failure to do so will not prevent exiting.
 #[command]
-pub async fn exit_app<R: Runtime>(app_handle: AppHandle<R>, settings: Settings) -> CmdResult<()> {
-    let persist_dir = app_handle.persist_dir();
-    if let Err(e) = settings.dump(persist_dir) {
+pub async fn exit_app<R: Runtime>(app_handle: AppHandle<R>, settings: Settings) -> () {
+    if let Err(e) = (|| {
+        let persist_dir = app_handle.persist_dir()?;
+        settings.dump(persist_dir)
+    })() {
         eprintln!("Failed to dump settings: {e}");
+        app_handle.exit(1);
+        return;
     }
-
     app_handle.exit(0);
-    Ok(())
 }

--- a/crates/deskulpt-core/src/commands/exit_app.rs
+++ b/crates/deskulpt-core/src/commands/exit_app.rs
@@ -9,7 +9,7 @@ use crate::settings::Settings;
 /// application in the end. Prior to exiting, it will try to dump the settings
 /// for persistence, but failure to do so will not prevent exiting.
 #[command]
-pub async fn exit_app<R: Runtime>(app_handle: AppHandle<R>, settings: Settings) -> () {
+pub async fn exit_app<R: Runtime>(app_handle: AppHandle<R>, settings: Settings) {
     if let Err(e) = (|| {
         let persist_dir = app_handle.persist_dir()?;
         settings.dump(persist_dir)

--- a/crates/deskulpt-core/src/commands/open_in_widgets_dir.rs
+++ b/crates/deskulpt-core/src/commands/open_in_widgets_dir.rs
@@ -12,13 +12,14 @@ use crate::path::PathExt;
 ///
 /// ### Errors
 ///
+/// - Failed to access the widgets directory.
 /// - Error opening the specified path.
 #[command]
 pub async fn open_in_widgets_dir<R: Runtime>(
     app_handle: AppHandle<R>,
     components: Vec<String>,
 ) -> CmdResult<()> {
-    let mut open_path = app_handle.widgets_dir().to_path_buf();
+    let mut open_path = app_handle.widgets_dir()?.to_path_buf();
     open_path.extend(components);
     open::that_detached(open_path)?;
 

--- a/crates/deskulpt-core/src/commands/rescan_widgets.rs
+++ b/crates/deskulpt-core/src/commands/rescan_widgets.rs
@@ -15,13 +15,14 @@ use crate::states::StatesExtWidgetConfigMap;
 ///
 /// ### Errors
 ///
+/// - Failed to access the widgets directory.
 /// - Error traversing the widgets directory.
 /// - Error inferring widget ID from the directory entry.
 #[command]
 pub async fn rescan_widgets<R: Runtime>(
     app_handle: AppHandle<R>,
 ) -> CmdResult<HashMap<String, WidgetConfig>> {
-    let widgets_dir = app_handle.widgets_dir();
+    let widgets_dir = app_handle.widgets_dir()?;
     let mut new_config_map = HashMap::new();
 
     let entries = read_dir(widgets_dir)?;

--- a/crates/deskulpt-core/src/path.rs
+++ b/crates/deskulpt-core/src/path.rs
@@ -33,6 +33,8 @@ pub trait PathExt<R: Runtime>: Manager<R> {
         Ok(())
     }
 
+    /// Get a reference to the widgets directory.
+    ///
     /// This will create the widgets directory if it does not exist, which can
     /// happen if one removes that directory during the application. This will
     /// error if the [`init_widgets_dir`](PathExt::init_widgets_dir) method has
@@ -66,6 +68,8 @@ pub trait PathExt<R: Runtime>: Manager<R> {
         Ok(())
     }
 
+    /// Get a reference to the persistence directory.
+    ///
     /// This will create the persistence directory if it does not exist, which
     /// can happen if one removes that directory during the application. This
     /// will error if the [`init_persist_dir`](PathExt::init_persist_dir) method

--- a/crates/deskulpt/src/lib.rs
+++ b/crates/deskulpt/src/lib.rs
@@ -20,7 +20,7 @@ pub fn run() {
             app.init_widgets_dir()?;
             app.init_persist_dir()?;
 
-            let settings = match Settings::load(app.persist_dir()) {
+            let settings = match Settings::load(app.persist_dir()?) {
                 Ok(settings) => settings,
                 Err(e) => {
                     eprintln!("Failed to load settings: {e}");


### PR DESCRIPTION
Extracted from #370.

As stated in the title, people can delete e.g. the widgets directory halfway when using the application. That will cause the problem of directory not found. Whenever we access it we should check if it exists and create it if it does not.