### PR TITLE
refactor: use uuid v5 instead of dir name as widget id

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -978,6 +978,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.9",
  "tokio",
+ "uuid",
 ]
 
 [[package]]
@@ -4676,6 +4677,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
+
+[[package]]
 name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5817,6 +5824,7 @@ checksum = "f8c5f0a0af699448548ad1a2fbf920fb4bee257eae39953ba95cb84891a0446a"
 dependencies = [
  "getrandom 0.2.15",
  "serde",
+ "sha1_smol",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ tauri-plugin-global-shortcut   = "2.2.0"
 tempfile                       = "3.15.0"
 thiserror                      = "2.0.9"
 tokio                          = "1.43.0"
+uuid                           = "1.11.0"
 
 # Deskulpt crates
 deskulpt-core          = { version = "0.0.1", path = "crates/deskulpt-core" }

--- a/crates/deskulpt-core/Cargo.toml
+++ b/crates/deskulpt-core/Cargo.toml
@@ -27,6 +27,7 @@ tauri-plugin-global-shortcut = { workspace = true }
 tempfile                     = { workspace = true }
 thiserror                    = { workspace = true }
 tokio                        = { workspace = true }
+uuid                         = { workspace = true, features = ["v5"] }
 
 # TODO: Remove these when finalized
 deskulpt-plugin     = { workspace = true } # maybe remove

--- a/crates/deskulpt-core/src/commands/call_plugin.rs
+++ b/crates/deskulpt-core/src/commands/call_plugin.rs
@@ -1,8 +1,10 @@
+use anyhow::anyhow;
 use once_cell::sync::Lazy;
 use tauri::{command, AppHandle};
 use tokio::sync::Mutex;
 
 use super::error::{cmdbail, CmdResult};
+use crate::{PathExt, StatesExtWidgetConfigMap};
 
 // TODO: Remove this temporary implementation
 static FS_PLUGIN: Lazy<Mutex<deskulpt_plugin_fs::FsPlugin>> =
@@ -32,17 +34,37 @@ pub async fn call_plugin(
     id: String,
     payload: Option<serde_json::Value>,
 ) -> CmdResult<serde_json::Value> {
+    let widget_dir_fn = move |id: &str| {
+        let widgets_dir = app_handle.widgets_dir()?;
+        app_handle.with_widget_config_map(|config_map| {
+            config_map
+                .get(id)
+                .ok_or_else(|| anyhow!("Widget {} not found in the collection", id))
+                .map(|config| widgets_dir.join(config.dir()))
+        })
+    };
+
     match plugin.as_str() {
         "fs" => {
             let plugin = FS_PLUGIN.lock().await;
-            let result =
-                deskulpt_plugin::call_plugin(app_handle, &*plugin, command.as_str(), id, payload)?;
+            let result = deskulpt_plugin::call_plugin(
+                widget_dir_fn,
+                &*plugin,
+                command.as_str(),
+                id,
+                payload,
+            )?;
             Ok(result)
         },
         "sys" => {
             let plugin = SYS_PLUGIN.lock().await;
-            let result =
-                deskulpt_plugin::call_plugin(app_handle, &*plugin, command.as_str(), id, payload)?;
+            let result = deskulpt_plugin::call_plugin(
+                widget_dir_fn,
+                &*plugin,
+                command.as_str(),
+                id,
+                payload,
+            )?;
             Ok(result)
         },
         _ => cmdbail!("Unknown plugin: {}", plugin),

--- a/crates/deskulpt-core/src/commands/rescan_widgets.rs
+++ b/crates/deskulpt-core/src/commands/rescan_widgets.rs
@@ -3,7 +3,7 @@ use std::fs::read_dir;
 
 use tauri::{command, AppHandle, Runtime};
 
-use super::error::{cmdbail, CmdResult};
+use super::error::CmdResult;
 use crate::config::WidgetConfig;
 use crate::path::PathExt;
 use crate::states::StatesExtWidgetConfigMap;
@@ -34,12 +34,8 @@ pub async fn rescan_widgets<R: Runtime>(
             continue; // Non-directory entries are not widgets, skip
         }
 
-        let id = match path.file_name() {
-            Some(file_name) => file_name.to_string_lossy().to_string(),
-            None => cmdbail!("Invalid widget directory: '{}'", path.display()),
-        };
-
         if let Some(widget_config) = WidgetConfig::load(&path) {
+            let id = widget_config.id();
             new_config_map.insert(id, widget_config);
         }
     }

--- a/crates/deskulpt-core/src/config.rs
+++ b/crates/deskulpt-core/src/config.rs
@@ -7,6 +7,7 @@ use std::path::Path;
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 /// Deserialized `deskulpt.conf.json`.
 #[derive(Clone, Deserialize, Serialize)]
@@ -132,5 +133,14 @@ impl WidgetConfig {
             WidgetConfig::Valid { dir, .. } => dir,
             WidgetConfig::Invalid { dir, .. } => dir,
         }
+    }
+
+    /// Get the widget ID.
+    ///
+    /// This ID is derived from the widget directory name using UUID v5. It is
+    /// deterministic for the same directory name.
+    pub fn id(&self) -> String {
+        let dir_encoded = self.dir().as_bytes();
+        Uuid::new_v5(&Uuid::NAMESPACE_URL, dir_encoded).to_string()
     }
 }

--- a/crates/deskulpt-plugin-fs/src/commands/append_file.rs
+++ b/crates/deskulpt-plugin-fs/src/commands/append_file.rs
@@ -30,7 +30,7 @@ impl PluginCommand for AppendFile {
         engine: &EngineInterface,
         input: AppendFileInputPayload,
     ) -> Result<()> {
-        let path = engine.widget_dir(id.as_str()).join(input.path);
+        let path = engine.widget_dir(id.as_str())?.join(input.path);
         let mut file = std::fs::OpenOptions::new().append(true).open(&path)?;
         file.write_all(input.content.as_bytes())?;
         Ok(())

--- a/crates/deskulpt-plugin-fs/src/commands/create_dir.rs
+++ b/crates/deskulpt-plugin-fs/src/commands/create_dir.rs
@@ -28,7 +28,7 @@ impl PluginCommand for CreateDir {
         engine: &EngineInterface,
         input: CreateDirInputPayload,
     ) -> Result<()> {
-        let path = engine.widget_dir(id.as_str()).join(input.path);
+        let path = engine.widget_dir(id.as_str())?.join(input.path);
         std::fs::create_dir_all(&path)?;
         Ok(())
     }

--- a/crates/deskulpt-plugin-fs/src/commands/exists.rs
+++ b/crates/deskulpt-plugin-fs/src/commands/exists.rs
@@ -28,7 +28,7 @@ impl PluginCommand for Exists {
         engine: &EngineInterface,
         input: ExistsInputPayload,
     ) -> Result<bool> {
-        let path = engine.widget_dir(id).join(input.path);
+        let path = engine.widget_dir(id)?.join(input.path);
         Ok(path.exists())
     }
 }

--- a/crates/deskulpt-plugin-fs/src/commands/is_dir.rs
+++ b/crates/deskulpt-plugin-fs/src/commands/is_dir.rs
@@ -28,7 +28,7 @@ impl PluginCommand for IsDir {
         engine: &EngineInterface,
         input: IsDirInputPayload,
     ) -> Result<bool> {
-        let path = engine.widget_dir(id.as_str()).join(input.path);
+        let path = engine.widget_dir(id.as_str())?.join(input.path);
         Ok(path.is_dir())
     }
 }

--- a/crates/deskulpt-plugin-fs/src/commands/is_file.rs
+++ b/crates/deskulpt-plugin-fs/src/commands/is_file.rs
@@ -28,7 +28,7 @@ impl PluginCommand for IsFile {
         engine: &EngineInterface,
         input: IsFileInputPayload,
     ) -> Result<bool> {
-        let path = engine.widget_dir(id.as_str()).join(input.path);
+        let path = engine.widget_dir(id.as_str())?.join(input.path);
         Ok(path.is_file())
     }
 }

--- a/crates/deskulpt-plugin-fs/src/commands/read_file.rs
+++ b/crates/deskulpt-plugin-fs/src/commands/read_file.rs
@@ -28,7 +28,7 @@ impl PluginCommand for ReadFile {
         engine: &EngineInterface,
         input: ReadFileInputPayload,
     ) -> Result<String> {
-        let path = engine.widget_dir(id.as_str()).join(input.path);
+        let path = engine.widget_dir(id.as_str())?.join(input.path);
         let content = std::fs::read_to_string(&path)?;
         Ok(content)
     }

--- a/crates/deskulpt-plugin-fs/src/commands/remove_dir.rs
+++ b/crates/deskulpt-plugin-fs/src/commands/remove_dir.rs
@@ -28,7 +28,7 @@ impl PluginCommand for RemoveDir {
         engine: &EngineInterface,
         input: RemoveDirInputPayload,
     ) -> Result<()> {
-        let path = engine.widget_dir(id.as_str()).join(input.path);
+        let path = engine.widget_dir(id.as_str())?.join(input.path);
         std::fs::remove_dir_all(&path)?;
         Ok(())
     }

--- a/crates/deskulpt-plugin-fs/src/commands/remove_file.rs
+++ b/crates/deskulpt-plugin-fs/src/commands/remove_file.rs
@@ -28,7 +28,7 @@ impl PluginCommand for RemoveFile {
         engine: &EngineInterface,
         input: RemoveFileInputPayload,
     ) -> Result<()> {
-        let path = engine.widget_dir(id.as_str()).join(input.path);
+        let path = engine.widget_dir(id.as_str())?.join(input.path);
         std::fs::remove_file(&path)?;
         Ok(())
     }

--- a/crates/deskulpt-plugin-fs/src/commands/write_file.rs
+++ b/crates/deskulpt-plugin-fs/src/commands/write_file.rs
@@ -29,7 +29,7 @@ impl PluginCommand for WriteFile {
         engine: &EngineInterface,
         input: WriteFileInputPayload,
     ) -> Result<()> {
-        let path = engine.widget_dir(id.as_str()).join(input.path);
+        let path = engine.widget_dir(id.as_str())?.join(input.path);
         std::fs::write(&path, input.content)?;
         Ok(())
     }

--- a/crates/deskulpt-plugin/src/interface.rs
+++ b/crates/deskulpt-plugin/src/interface.rs
@@ -2,24 +2,28 @@
 
 use std::path::PathBuf;
 
-use tauri::{AppHandle, Manager};
+use anyhow::Result;
 
 /// The interface for interacting with the Deskulpt engine (🚧 TODO 🚧).
 ///
 /// ### 🚧 TODO 🚧
 ///
-/// This is a temporary implementation that directly uses the app handle of the
-/// Deskulpt core because the plugin currently runs in the same process. The
-/// final implementation should use IPC for communication, and this struct may
-/// need to hold the IPC channel, etc.
+/// This is a temporary implementation that directly takes the necessary
+/// functions for the engine interface from the Deskulpt core, because the
+/// plugins currently run in the same process as the core. The final
+/// implementation should not require this and should use IPC for communication.
+/// This struct may need to hold the IPC channel, etc. instead.
 pub struct EngineInterface {
-    app_handle: AppHandle,
+    #[allow(clippy::type_complexity)]
+    widget_dir_fn: Box<dyn Fn(&str) -> Result<PathBuf>>,
 }
 
 impl EngineInterface {
     /// Create a new engine interface instance.
-    pub(crate) fn new(app_handle: AppHandle) -> Self {
-        Self { app_handle }
+    pub(crate) fn new(widget_dir_fn: impl Fn(&str) -> Result<PathBuf> + 'static) -> Self {
+        Self {
+            widget_dir_fn: Box::new(widget_dir_fn),
+        }
     }
 
     /// Get the directory of a widget (🚧 TODO 🚧).
@@ -29,12 +33,7 @@ impl EngineInterface {
     /// This method is a temporary implementation. The final implementation
     /// should use IPC to communicate with the Deskulpt core to get the widget
     /// directory.
-    pub fn widget_dir<S: AsRef<str>>(&self, id: S) -> PathBuf {
-        self.app_handle
-            .path()
-            .resource_dir()
-            .unwrap()
-            .join("widgets")
-            .join(id.as_ref())
+    pub fn widget_dir<S: AsRef<str>>(&self, id: S) -> Result<PathBuf> {
+        (self.widget_dir_fn)(id.as_ref())
     }
 }

--- a/crates/deskulpt-plugin/src/lib.rs
+++ b/crates/deskulpt-plugin/src/lib.rs
@@ -7,10 +7,11 @@
 mod command;
 mod interface;
 
+use std::path::PathBuf;
+
 use anyhow::{bail, Result};
 pub use command::PluginCommand;
 pub use interface::EngineInterface;
-use tauri::AppHandle;
 pub use {anyhow, serde_json};
 
 /// The API for a Deskulpt plugin.
@@ -40,13 +41,13 @@ pub trait Plugin {
 /// [nushell](https://docs.rs/nu-plugin/0.101.0/nu_plugin/fn.serve_plugin.html)
 /// for reference.
 pub fn call_plugin<P: Plugin>(
-    app_handle: AppHandle,
+    widget_dir_fn: impl Fn(&str) -> Result<PathBuf> + 'static,
     plugin: &P,
     command: &str,
     id: String,
     payload: Option<serde_json::Value>,
 ) -> Result<serde_json::Value> {
-    let engine = EngineInterface::new(app_handle);
+    let engine = EngineInterface::new(widget_dir_fn);
 
     for plugin_command in plugin.commands() {
         if plugin_command.name() == command {

--- a/src/manager/components/WidgetContent.tsx
+++ b/src/manager/components/WidgetContent.tsx
@@ -63,7 +63,9 @@ export default function WidgetContent({
           }
           actionIcon={<LuFolderOpen />}
           actionText="Edit"
-          action={() => invokeOpenInWidgetsDir({ components: [id] })}
+          action={() =>
+            invokeOpenInWidgetsDir({ components: [config.content.dir] })
+          }
         />
         <ScrollArea scrollbars="vertical" asChild>
           <Box px="2" css={{ flex: 3 }}>

--- a/src/manager/components/WidgetContentConfigList.tsx
+++ b/src/manager/components/WidgetContentConfigList.tsx
@@ -42,7 +42,7 @@ export default function WidgetContentConfigList({
                 size="1"
                 onClick={() =>
                   invokeOpenInWidgetsDir({
-                    components: [id, config.content.entry],
+                    components: [config.content.dir, config.content.entry],
                   })
                 }
               >


### PR DESCRIPTION
Extracted from #370.

This is not for security reasons (at least not for now) because uuid v5 is unique as long as namespace is known (which can easily be found from our source code). This is mainly such that users do not use IDs mistakenly (using paths it is too easy for them to know what the ID is).

The reason for choosing uuid v5 is that it is deterministic, so that as long as widget directory did not change, it has the same widget ID. This saves the effort of e.g. comparing paths to identify which widgets are added/removed.