### PR TITLE
enh: include trace in widget configuration errors

### DIFF
--- a/crates/deskulpt-core/src/config.rs
+++ b/crates/deskulpt-core/src/config.rs
@@ -98,7 +98,7 @@ impl WidgetConfig {
                 Err(e) => {
                     return Some(WidgetConfig::Invalid {
                         dir: dir_name.to_string(),
-                        error: e.to_string(),
+                        error: format!("{e:?}"),
                     })
                 },
             };
@@ -114,7 +114,7 @@ impl WidgetConfig {
             Err(e) => {
                 return Some(WidgetConfig::Invalid {
                     dir: dir_name.to_string(),
-                    error: e.to_string(),
+                    error: format!("{e:?}"),
                 })
             },
         };


### PR DESCRIPTION
Extracted from #370.

`.to_string` on `anyhow::Error` uses display formatting and does not include the error chain, only the debug formatting does. This is useful for providing more information to users. Instead of just saying e.g. `error in deskulpt.config.json`, it will also mention why, e.g. which field in the JSON is missing or something like that.