### PR TITLE
chore: serde rename to camel case unless in rare cases

### DIFF
--- a/crates/deskulpt-core/src/events.rs
+++ b/crates/deskulpt-core/src/events.rs
@@ -6,7 +6,7 @@ use tauri::{App, AppHandle, Emitter, Runtime};
 
 /// Payload of the `show-toast` event.
 #[derive(Serialize, Clone)]
-#[serde(rename_all = "lowercase")]
+#[serde(rename_all = "camelCase")]
 pub enum ShowToastPayload {
     /// Show a [success](https://sonner.emilkowal.ski/toast#success) toast.
     Success(String),

--- a/crates/deskulpt-core/src/settings.rs
+++ b/crates/deskulpt-core/src/settings.rs
@@ -13,7 +13,7 @@ static SETTINGS_FILE: &str = "settings.bin";
 
 /// Light/dark theme of the application.
 #[derive(Default, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "lowercase")]
 enum Theme {
     #[default]
     Light,
@@ -46,6 +46,7 @@ struct AppSettings {
 /// Different from widget configurations, these are independent of the widget
 /// configuration files and are managed internally by the application.
 #[derive(Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
 struct WidgetSettings {
     /// The leftmost x-coordinate in pixels.
     x: i32,

--- a/crates/deskulpt-plugin-fs/src/commands/append_file.rs
+++ b/crates/deskulpt-plugin-fs/src/commands/append_file.rs
@@ -10,6 +10,7 @@ use crate::FsPlugin;
 pub struct AppendFile;
 
 #[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct AppendFileInputPayload {
     path: PathBuf,
     content: String,

--- a/crates/deskulpt-plugin-fs/src/commands/create_dir.rs
+++ b/crates/deskulpt-plugin-fs/src/commands/create_dir.rs
@@ -9,6 +9,7 @@ use crate::FsPlugin;
 pub struct CreateDir;
 
 #[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct CreateDirInputPayload {
     path: PathBuf,
 }

--- a/crates/deskulpt-plugin-fs/src/commands/exists.rs
+++ b/crates/deskulpt-plugin-fs/src/commands/exists.rs
@@ -9,6 +9,7 @@ use crate::FsPlugin;
 pub struct Exists;
 
 #[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ExistsInputPayload {
     path: PathBuf,
 }

--- a/crates/deskulpt-plugin-fs/src/commands/is_dir.rs
+++ b/crates/deskulpt-plugin-fs/src/commands/is_dir.rs
@@ -9,6 +9,7 @@ use crate::FsPlugin;
 pub struct IsDir;
 
 #[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct IsDirInputPayload {
     path: PathBuf,
 }

--- a/crates/deskulpt-plugin-fs/src/commands/is_file.rs
+++ b/crates/deskulpt-plugin-fs/src/commands/is_file.rs
@@ -9,6 +9,7 @@ use crate::FsPlugin;
 pub struct IsFile;
 
 #[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct IsFileInputPayload {
     path: PathBuf,
 }

--- a/crates/deskulpt-plugin-fs/src/commands/read_file.rs
+++ b/crates/deskulpt-plugin-fs/src/commands/read_file.rs
@@ -9,6 +9,7 @@ use crate::FsPlugin;
 pub struct ReadFile;
 
 #[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct ReadFileInputPayload {
     path: PathBuf,
 }

--- a/crates/deskulpt-plugin-fs/src/commands/remove_dir.rs
+++ b/crates/deskulpt-plugin-fs/src/commands/remove_dir.rs
@@ -9,6 +9,7 @@ use crate::FsPlugin;
 pub struct RemoveDir;
 
 #[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct RemoveDirInputPayload {
     path: PathBuf,
 }

--- a/crates/deskulpt-plugin-fs/src/commands/remove_file.rs
+++ b/crates/deskulpt-plugin-fs/src/commands/remove_file.rs
@@ -9,6 +9,7 @@ use crate::FsPlugin;
 pub struct RemoveFile;
 
 #[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct RemoveFileInputPayload {
     path: PathBuf,
 }

--- a/crates/deskulpt-plugin-fs/src/commands/write_file.rs
+++ b/crates/deskulpt-plugin-fs/src/commands/write_file.rs
@@ -9,6 +9,7 @@ use crate::FsPlugin;
 pub struct WriteFile;
 
 #[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct WriteFileInputPayload {
     path: PathBuf,
     content: String,


### PR DESCRIPTION
Extracted from #370.

The concensus is: enum variants are SCREAMING_SNAKE_CASE and others are camelCase. On in special cases can this rule be broken, e.g. `Theme` is easier to work with in lowercase (rather than SCREAMING_SNAKE_CASE) because some component libraries take the `theme` prop as `"light" | "dark"`. Note that we put `#[serde(rename_all = "camelCase")]` even in cases where this does not have any effect (i.e., when it is only one word). This is for consistency considerations, and in case if we changed the naming or added more props in the future things automatically works.