### PR TITLE
chore: move views/x.html to x/index.html

### DIFF
--- a/crates/deskulpt-core/src/window/mod.rs
+++ b/crates/deskulpt-core/src/window/mod.rs
@@ -16,7 +16,7 @@ pub trait WindowExt<R: Runtime>: Manager<R> {
     where
         Self: Sized,
     {
-        let url = WebviewUrl::App("views/manager.html".into());
+        let url = WebviewUrl::App("manager/index.html".into());
         let init_js = ManagerInitJS::generate(settings)?;
         WebviewWindowBuilder::new(self, "manager", url)
             .title("Deskulpt Manager")
@@ -37,7 +37,7 @@ pub trait WindowExt<R: Runtime>: Manager<R> {
     where
         Self: Sized,
     {
-        let url = WebviewUrl::App("views/canvas.html".into());
+        let url = WebviewUrl::App("canvas/index.html".into());
         let init_js = CanvasInitJS::generate(settings)?;
         let canvas = WebviewWindowBuilder::new(self, "canvas", url)
             .maximized(true)

--- a/src/canvas/index.html
+++ b/src/canvas/index.html
@@ -9,6 +9,6 @@
 
   <body style="overflow: hidden; margin: 0">
     <div id="root"></div>
-    <script type="module" src="/canvas/main.tsx"></script>
+    <script type="module" src="main.tsx"></script>
   </body>
 </html>

--- a/src/manager/index.html
+++ b/src/manager/index.html
@@ -9,6 +9,6 @@
 
   <body style="overflow: hidden; margin: 0">
     <div id="root"></div>
-    <script type="module" src="/manager/main.tsx"></script>
+    <script type="module" src="main.tsx"></script>
   </body>
 </html>

--- a/src/vite.config.ts
+++ b/src/vite.config.ts
@@ -19,8 +19,8 @@ export default defineConfig({
   build: {
     rollupOptions: {
       input: {
-        manager: resolve(__dirname, "views/manager.html"),
-        canvas: resolve(__dirname, "views/canvas.html"),
+        manager: resolve(__dirname, "manager/index.html"),
+        canvas: resolve(__dirname, "canvas/index.html"),
         // Make the scripts entrypoints so that they are preserved even if not imported
         "generated/jsx-runtime": resolve(__dirname, "generated/jsx-runtime.js"),
         "generated/raw-apis": resolve(__dirname, "generated/raw-apis.js"),


### PR DESCRIPTION
Extracted from #370.

This is a more intuitive and natural structuring.