### PR TITLE
refactor: use zustand for canvas widgets state management

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,6 +140,9 @@ importers:
       sonner:
         specifier: ^1.7.1
         version: 1.7.1(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      zustand:
+        specifier: ^5.0.3
+        version: 5.0.3(@types/react@19.0.2)(immer@9.0.21)(react@19.0.0)
     devDependencies:
       '@emotion/babel-plugin':
         specifier: ^11.13.5
@@ -7778,6 +7781,24 @@ packages:
   yocto-queue@1.1.1:
     resolution: {integrity: sha512-b4JR1PFR10y1mKjhHY9LaGo6tmrgjit7hxVIeAmyMw3jegXR4dhYqLaQF5zMXZxY7tLpMyJeLjr1C4rLmkVe8g==}
     engines: {node: '>=12.20'}
+
+  zustand@5.0.3:
+    resolution: {integrity: sha512-14fwWQtU3pH4dE0dOpdMiWjddcH+QzKIgk1cl8epwSE7yag43k/AD/m4L6+K7DytAOr9gGBe3/EXj9g7cdostg==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -17090,5 +17111,11 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   yocto-queue@1.1.1: {}
+
+  zustand@5.0.3(@types/react@19.0.2)(immer@9.0.21)(react@19.0.0):
+    optionalDependencies:
+      '@types/react': 19.0.2
+      immer: 9.0.21
+      react: 19.0.0
 
   zwitch@2.0.4: {}

--- a/src/canvas/hooks/useRemoveWidgetsListener.tsx
+++ b/src/canvas/hooks/useRemoveWidgetsListener.tsx
@@ -1,25 +1,18 @@
-import { Dispatch, SetStateAction, useEffect } from "react";
+import { useEffect } from "react";
 import { listenToRemoveWidgets } from "../../events";
-import { CanvasWidgetState } from "../../types/frontend";
+import { removeWidgets, useWidgetsStore } from "./useWidgetsStore";
 
 /**
  * Listen and react to the "remove-widgets" event.
- *
- * @param canvasWidgetStates Canvas widget states.
- * @param setCanvasWidgetStates Setter for the canvas widget states.
  */
-export default function useRemoveWidgetsListener(
-  canvasWidgetStates: Record<string, CanvasWidgetState>,
-  setCanvasWidgetStates: Dispatch<
-    SetStateAction<Record<string, CanvasWidgetState>>
-  >,
-) {
+export default function useRemoveWidgetsListener() {
   useEffect(() => {
     const unlisten = listenToRemoveWidgets((event) => {
       const { removedIds } = event.payload;
+      const widgets = useWidgetsStore.getState().widgets;
 
       removedIds.forEach((id) => {
-        const state = canvasWidgetStates[id];
+        const state = widgets[id];
         if (state === null) {
           return; // This should not happen but let us be safe
         }
@@ -33,16 +26,11 @@ export default function useRemoveWidgetsListener(
         }
       });
 
-      // Remove the specified widgets from the canvas states
-      setCanvasWidgetStates((prev) =>
-        Object.fromEntries(
-          Object.entries(prev).filter(([id]) => !removedIds.includes(id)),
-        ),
-      );
+      removeWidgets(removedIds);
     });
 
     return () => {
       unlisten.then((f) => f()).catch(console.error);
     };
-  }, [canvasWidgetStates, setCanvasWidgetStates]);
+  }, []);
 }

--- a/src/canvas/hooks/useWidgetsStore.ts
+++ b/src/canvas/hooks/useWidgetsStore.ts
@@ -1,0 +1,146 @@
+import { create } from "zustand";
+import { WidgetSettings } from "../../types/backend";
+import { FC, createElement } from "react";
+import ErrorDisplay from "../components/ErrorDisplay";
+import { grabErrorInfo } from "../utils";
+
+export interface Widget {
+  Component: FC<{ id: string }>;
+  width?: string;
+  height?: string;
+}
+
+export interface WidgetState extends Widget, WidgetSettings {
+  apisBlobUrl: string;
+  moduleBlobUrl?: string;
+}
+
+export const useWidgetsStore = create(() => ({
+  widgets: {} as Record<string, WidgetState>,
+}));
+
+/**
+ * Update rendering information of a widget.
+ *
+ * If the widget is in the store, rendering information will be updated, and the
+ * settings will be ignored. Otherwise, the settings are required and a new
+ * widget will be added to the store.
+ */
+export function updateWidgetRender(
+  id: string,
+  widget: Widget,
+  moduleBlobUrl: string,
+  apisBlobUrl: string,
+  settings?: WidgetSettings,
+) {
+  useWidgetsStore.setState((state) => {
+    if (id in state.widgets) {
+      return {
+        widgets: {
+          ...state.widgets,
+          [id]: {
+            ...state.widgets[id],
+            // Not using spread syntax because undefined properties in the
+            // widget need to override their previous values as well
+            Component: widget.Component,
+            width: widget.width,
+            height: widget.height,
+            moduleBlobUrl,
+          },
+        },
+      };
+    }
+    if (settings !== undefined) {
+      return {
+        widgets: {
+          ...state.widgets,
+          [id]: { ...widget, ...settings, apisBlobUrl, moduleBlobUrl },
+        },
+      };
+    }
+    return state;
+  });
+}
+
+/**
+ * Update rendering error of a widget.
+ *
+ * If the widget is in the store, its rendering information will be overridden
+ * with the error and the settings will be ignored. Otherwise, the settings are
+ * required and a new widget will be added to the store with the error.
+ */
+export function updateWidgetRenderError(
+  id: string,
+  error: unknown,
+  apisBlobUrl: string,
+  settings?: WidgetSettings,
+) {
+  useWidgetsStore.setState((state) => {
+    if (id in state.widgets) {
+      return {
+        widgets: {
+          ...state.widgets,
+          [id]: {
+            ...state.widgets[id],
+            Component: () =>
+              createElement(ErrorDisplay, {
+                title: id,
+                error: grabErrorInfo(error),
+              }),
+            width: undefined,
+            height: undefined,
+            moduleBlobUrl: undefined,
+          },
+        },
+      };
+    }
+    if (settings !== undefined) {
+      return {
+        widgets: {
+          ...state.widgets,
+          [id]: {
+            ...settings,
+            Component: () =>
+              createElement(ErrorDisplay, {
+                title: id,
+                error: grabErrorInfo(error),
+              }),
+            apisBlobUrl,
+          },
+        },
+      };
+    }
+    return state;
+  });
+}
+
+/**
+ * Update (partial) settings of a widget.
+ */
+export function updateWidgetSettings(
+  id: string,
+  settings: Partial<WidgetSettings>,
+) {
+  useWidgetsStore.setState((state) => {
+    if (id in state.widgets) {
+      return {
+        widgets: {
+          ...state.widgets,
+          [id]: { ...state.widgets[id], ...settings },
+        },
+      };
+    }
+    return state;
+  });
+}
+
+/**
+ * Remove a batch of widgets from the store.
+ */
+export function removeWidgets(ids: string[]) {
+  useWidgetsStore.setState((state) => ({
+    widgets: Object.fromEntries(
+      Object.entries(state.widgets).filter(([id]) => !ids.includes(id)),
+    ),
+  }));
+}

--- a/src/package.json
+++ b/src/package.json
@@ -18,7 +18,8 @@
     "react-draggable": "^4.4.6",
     "react-error-boundary": "^5.0.0",
     "react-icons": "^5.4.0",
-    "sonner": "^1.7.1"
+    "sonner": "^1.7.1",
+    "zustand": "^5.0.3"
   },
   "devDependencies": {
     "@emotion/babel-plugin": "^11.13.5",

--- a/src/types/frontend.ts
+++ b/src/types/frontend.ts
@@ -3,27 +3,11 @@
  * without corresponding backend implementations.
  */
 
-import { ReactNode } from "react";
 import { WidgetConfig, WidgetSettings } from "./backend";
 
 export type DeepReadonly<T> = {
   readonly [P in keyof T]: T[P] extends object ? DeepReadonly<T[P]> : T[P];
 };
-
-/**
- * The user-defined widget interface.
- *
- * The entry file of each user-defined widget should export an object that fulfills this
- * interface as default.
- */
-export interface Widget {
-  /** Function that returns the React component to render. */
-  render: () => ReactNode;
-  /** Widget widget as accepted in CSS. */
-  width: string;
-  /** Widget height as accepted in CSS. */
-  height: string;
-}
 
 /**
  * The state of a widget in the manager.
@@ -33,32 +17,6 @@ export interface ManagerWidgetState {
   config: WidgetConfig;
   /** Settings of the widget. */
   settings: WidgetSettings;
-}
-
-/**
- * The state of a widget on the canvas.
- */
-export interface CanvasWidgetState {
-  /** The rendered widget component or the error component to display. */
-  display: ReactNode;
-  /** The width of the widget container, as exported from the widget module. */
-  width: Widget["width"];
-  /** The height of the widget container, as exported from the widget module. */
-  height: Widget["height"];
-  /** Settings of the widget. */
-  settings: WidgetSettings;
-  /** The URL of the blob of widget APIs. */
-  apisBlobUrl: string;
-  /** The URL of the blob of the widget module. */
-  moduleBlobUrl?: string;
-}
-
-/**
- * The module obtained by dynamically importing the bundle of widget source code.
- */
-export interface WidgetModule {
-  /** The default export of the entry file of a user-defined widget. */
-  default: Widget;
 }
 
 /**


### PR DESCRIPTION
Alternative to part of #370.

This PR introduces a react state management library [zustand](https://zustand.docs.pmnd.rs/getting-started/introduction) which is the most popular one nowadays. Compared to what we did in #370,

- Widgets do not need to be passed everywhere - it can be obtained from the store.
- We can implement set state functions that achieves the same result as with `useReducer`. But there is also no need to pass the dispatch function everywhere - the functions are standalone and can be directly imported for use.
- Zustand does not restrict to using pure functions, but `useReducer` does, which would require additional `useCallback` to construct non-pure functions on top of the dispatch function. With Zustand this is not necessary.
- We can reduce a lot of typing, since we do not need to pass the state and props down the tree.

Some additional changes introduced by this PR:

- Widgets are previously require `render: () => React.ReactNode`. Now they instead require `Component: React.FC<{ id: string }>`, which becomes much more flexible. We can easily pass props to the widget, and with this change we can solve #328 by adding `x: number` and `y: number` as well.
- `width` and `height` are no longer required from the widget. If not given, they use the default `300x150px` size.

Some future work that are to be done in subsequent PRs:

- Memoize component to avoid unnecessary rerenders.
- The canvas `App` actually only depends on which widgets are there but not what the widgets actually look like. Thus by depending only on the keys in `App` can reduce rerenders. The specific widget props and configurations can be obtained separately from the store in `WidgetContainer`.