### PR TITLE
refactor: style of writing react components

### DIFF
--- a/src/canvas/components/ErrorDisplay.tsx
+++ b/src/canvas/components/ErrorDisplay.tsx
@@ -1,5 +1,4 @@
 import { Badge, Box, Flex, Heading, ScrollArea, Text } from "@radix-ui/themes";
-import { memo } from "react";
 
 interface ErrorDisplayProps {
   /** Title of the error display. */
@@ -15,7 +14,7 @@ interface ErrorDisplayProps {
  * error message displayed as pre-wrap monospace text. The component is wrapped in a
  * scroll area is scrollable in both directions.
  */
-const ErrorDisplay = memo(({ title, error }: ErrorDisplayProps) => {
+const ErrorDisplay = ({ title, error }: ErrorDisplayProps) => {
   return (
     <ScrollArea scrollbars="both" asChild>
       <Box p="2">
@@ -36,6 +35,6 @@ const ErrorDisplay = memo(({ title, error }: ErrorDisplayProps) => {
       </Box>
     </ScrollArea>
   );
-});
+};
 
 export default ErrorDisplay;

--- a/src/canvas/components/ErrorDisplay.tsx
+++ b/src/canvas/components/ErrorDisplay.tsx
@@ -1,6 +1,7 @@
 import { Badge, Box, Flex, Heading, ScrollArea, Text } from "@radix-ui/themes";
+import { memo } from "react";
 
-export interface ErrorDisplayProps {
+interface ErrorDisplayProps {
   /** Title of the error display. */
   title: string;
   /** The full error message. */
@@ -14,7 +15,7 @@ export interface ErrorDisplayProps {
  * error message displayed as pre-wrap monospace text. The component is wrapped in a
  * scroll area is scrollable in both directions.
  */
-export default function ErrorDisplay({ title, error }: ErrorDisplayProps) {
+const ErrorDisplay = memo(({ title, error }: ErrorDisplayProps) => {
   return (
     <ScrollArea scrollbars="both" asChild>
       <Box p="2">
@@ -35,4 +36,6 @@ export default function ErrorDisplay({ title, error }: ErrorDisplayProps) {
       </Box>
     </ScrollArea>
   );
-}
+});
+
+export default ErrorDisplay;

--- a/src/canvas/components/WidgetContainer.tsx
+++ b/src/canvas/components/WidgetContainer.tsx
@@ -1,4 +1,4 @@
-import { RefObject, useRef } from "react";
+import { RefObject, memo, useRef } from "react";
 import Draggable, { DraggableData, DraggableEvent } from "react-draggable";
 import { ErrorBoundary } from "react-error-boundary";
 import ErrorDisplay from "../components/ErrorDisplay";
@@ -8,7 +8,7 @@ import { Box } from "@radix-ui/themes";
 import { WidgetState, updateWidgetSettings } from "../hooks/useWidgetsStore";
 import { emitUpdateSettingsToManager } from "../../events";
 
-export interface WidgetContainerProps {
+interface WidgetContainerProps {
   /** ID of the widget. */
   id: string;
   /** The widget state. */
@@ -25,7 +25,7 @@ export interface WidgetContainerProps {
  * If the child (i.e., the widget) throws a rendering error, it will be caught by the
  * error boundary and displayed with the {@link ErrorDisplay} component.
  */
-export default function WidgetContainer({ id, widget }: WidgetContainerProps) {
+const WidgetContainer = memo(({ id, widget }: WidgetContainerProps) => {
   const { Component, width, height, x, y, opacity } = widget;
   const containerRef = useRef<HTMLDivElement>(null);
   let retried = false;
@@ -107,4 +107,6 @@ export default function WidgetContainer({ id, widget }: WidgetContainerProps) {
       </Box>
     </Draggable>
   );
-}
+});
+
+export default WidgetContainer;

--- a/src/canvas/components/WidgetContainer.tsx
+++ b/src/canvas/components/WidgetContainer.tsx
@@ -1,4 +1,4 @@
-import { RefObject, memo, useRef } from "react";
+import { RefObject, useRef } from "react";
 import Draggable, { DraggableData, DraggableEvent } from "react-draggable";
 import { ErrorBoundary } from "react-error-boundary";
 import ErrorDisplay from "../components/ErrorDisplay";
@@ -25,7 +25,7 @@ interface WidgetContainerProps {
  * If the child (i.e., the widget) throws a rendering error, it will be caught by the
  * error boundary and displayed with the {@link ErrorDisplay} component.
  */
-const WidgetContainer = memo(({ id, widget }: WidgetContainerProps) => {
+const WidgetContainer = ({ id, widget }: WidgetContainerProps) => {
   const { Component, width, height, x, y, opacity } = widget;
   const containerRef = useRef<HTMLDivElement>(null);
   let retried = false;
@@ -107,6 +107,6 @@ const WidgetContainer = memo(({ id, widget }: WidgetContainerProps) => {
       </Box>
     </Draggable>
   );
-});
+};
 
 export default WidgetContainer;

--- a/src/manager/components/ExternalCopyLink.tsx
+++ b/src/manager/components/ExternalCopyLink.tsx
@@ -9,7 +9,7 @@ import {
 import { RxCopy } from "react-icons/rx";
 import { writeText } from "@tauri-apps/plugin-clipboard-manager";
 import { toast } from "sonner";
-import { PropsWithChildren, memo } from "react";
+import { PropsWithChildren } from "react";
 
 interface ExternalCopyLinkProps {
   /** The external target of the link. */
@@ -24,29 +24,31 @@ interface ExternalCopyLinkProps {
  * The link will be opened in a new tab when clicked. The copy button will copy the link
  * address to the clipboard. Wrap the link text within this component.
  */
-const ExternalCopyLink = memo(
-  ({ href, gap = "3", children }: PropsWithChildren<ExternalCopyLinkProps>) => {
-    return (
-      <Flex gap={gap} align="center">
-        <Link href={href} target="_blank" rel="noreferrer">
-          {children}
-        </Link>
-        <Tooltip content="Copy link" side="right">
-          <IconButton
-            size="1"
-            variant="ghost"
-            onClick={() =>
-              writeText(
-                "https://csci-shu-410-se-project.github.io/Deskulpt/",
-              ).then(() => toast.success("Copied to clipboard."))
-            }
-          >
-            <RxCopy />
-          </IconButton>
-        </Tooltip>
-      </Flex>
-    );
-  },
-);
+const ExternalCopyLink = ({
+  href,
+  gap = "3",
+  children,
+}: PropsWithChildren<ExternalCopyLinkProps>) => {
+  return (
+    <Flex gap={gap} align="center">
+      <Link href={href} target="_blank" rel="noreferrer">
+        {children}
+      </Link>
+      <Tooltip content="Copy link" side="right">
+        <IconButton
+          size="1"
+          variant="ghost"
+          onClick={() =>
+            writeText(
+              "https://csci-shu-410-se-project.github.io/Deskulpt/",
+            ).then(() => toast.success("Copied to clipboard."))
+          }
+        >
+          <RxCopy />
+        </IconButton>
+      </Tooltip>
+    </Flex>
+  );
+};
 
 export default ExternalCopyLink;

--- a/src/manager/components/ExternalCopyLink.tsx
+++ b/src/manager/components/ExternalCopyLink.tsx
@@ -9,9 +9,9 @@ import {
 import { RxCopy } from "react-icons/rx";
 import { writeText } from "@tauri-apps/plugin-clipboard-manager";
 import { toast } from "sonner";
-import { PropsWithChildren } from "react";
+import { PropsWithChildren, memo } from "react";
 
-export interface ExternalCopyLinkProps {
+interface ExternalCopyLinkProps {
   /** The external target of the link. */
   href: LinkProps["href"];
   /** The gap size between the link text and the copy button. */
@@ -24,29 +24,29 @@ export interface ExternalCopyLinkProps {
  * The link will be opened in a new tab when clicked. The copy button will copy the link
  * address to the clipboard. Wrap the link text within this component.
  */
-export default function ExternalCopyLink({
-  href,
-  gap = "3",
-  children,
-}: PropsWithChildren<ExternalCopyLinkProps>) {
-  return (
-    <Flex gap={gap} align="center">
-      <Link href={href} target="_blank" rel="noreferrer">
-        {children}
-      </Link>
-      <Tooltip content="Copy link" side="right">
-        <IconButton
-          size="1"
-          variant="ghost"
-          onClick={() =>
-            writeText(
-              "https://csci-shu-410-se-project.github.io/Deskulpt/",
-            ).then(() => toast.success("Copied to clipboard."))
-          }
-        >
-          <RxCopy />
-        </IconButton>
-      </Tooltip>
-    </Flex>
-  );
-}
+const ExternalCopyLink = memo(
+  ({ href, gap = "3", children }: PropsWithChildren<ExternalCopyLinkProps>) => {
+    return (
+      <Flex gap={gap} align="center">
+        <Link href={href} target="_blank" rel="noreferrer">
+          {children}
+        </Link>
+        <Tooltip content="Copy link" side="right">
+          <IconButton
+            size="1"
+            variant="ghost"
+            onClick={() =>
+              writeText(
+                "https://csci-shu-410-se-project.github.io/Deskulpt/",
+              ).then(() => toast.success("Copied to clipboard."))
+            }
+          >
+            <RxCopy />
+          </IconButton>
+        </Tooltip>
+      </Flex>
+    );
+  },
+);
+
+export default ExternalCopyLink;

--- a/src/manager/components/FloatButton.tsx
+++ b/src/manager/components/FloatButton.tsx
@@ -42,4 +42,5 @@ const FloatButton = ({
     </Box>
   );
 };
+
 export default FloatButton;

--- a/src/manager/components/FloatButton.tsx
+++ b/src/manager/components/FloatButton.tsx
@@ -1,7 +1,7 @@
 import { Box, IconButton, Tooltip } from "@radix-ui/themes";
-import { ReactNode } from "react";
+import { ReactNode, memo } from "react";
 
-export interface FloatButtonProps {
+interface FloatButtonProps {
   /** The order of the button, i.e., `(order - 1) * 40` pixels away from the bottom. */
   order: number;
   /** The icon to display in the float button. */
@@ -20,25 +20,23 @@ export interface FloatButtonProps {
  * This will be a circular icon button with a tooltip on hover, rendered in the bottom
  * right corner of the window.
  */
-export default function FloatButton({
-  order,
-  icon,
-  tooltip,
-  onClick,
-  disabled,
-}: FloatButtonProps) {
-  return (
-    <Box position="absolute" right="0" bottom={`${(order - 1) * 40}px`}>
-      <Tooltip content={tooltip} side="left">
-        <IconButton
-          variant="surface"
-          radius="full"
-          disabled={disabled}
-          onClick={onClick}
-        >
-          {icon}
-        </IconButton>
-      </Tooltip>
-    </Box>
-  );
-}
+const FloatButton = memo(
+  ({ order, icon, tooltip, onClick, disabled }: FloatButtonProps) => {
+    return (
+      <Box position="absolute" right="0" bottom={`${(order - 1) * 40}px`}>
+        <Tooltip content={tooltip} side="left">
+          <IconButton
+            variant="surface"
+            radius="full"
+            disabled={disabled}
+            onClick={onClick}
+          >
+            {icon}
+          </IconButton>
+        </Tooltip>
+      </Box>
+    );
+  },
+);
+
+export default FloatButton;

--- a/src/manager/components/FloatButton.tsx
+++ b/src/manager/components/FloatButton.tsx
@@ -1,5 +1,5 @@
 import { Box, IconButton, Tooltip } from "@radix-ui/themes";
-import { ReactNode, memo } from "react";
+import { ReactNode } from "react";
 
 interface FloatButtonProps {
   /** The order of the button, i.e., `(order - 1) * 40` pixels away from the bottom. */
@@ -20,23 +20,26 @@ interface FloatButtonProps {
  * This will be a circular icon button with a tooltip on hover, rendered in the bottom
  * right corner of the window.
  */
-const FloatButton = memo(
-  ({ order, icon, tooltip, onClick, disabled }: FloatButtonProps) => {
-    return (
-      <Box position="absolute" right="0" bottom={`${(order - 1) * 40}px`}>
-        <Tooltip content={tooltip} side="left">
-          <IconButton
-            variant="surface"
-            radius="full"
-            disabled={disabled}
-            onClick={onClick}
-          >
-            {icon}
-          </IconButton>
-        </Tooltip>
-      </Box>
-    );
-  },
-);
-
+const FloatButton = ({
+  order,
+  icon,
+  tooltip,
+  onClick,
+  disabled,
+}: FloatButtonProps) => {
+  return (
+    <Box position="absolute" right="0" bottom={`${(order - 1) * 40}px`}>
+      <Tooltip content={tooltip} side="left">
+        <IconButton
+          variant="surface"
+          radius="full"
+          disabled={disabled}
+          onClick={onClick}
+        >
+          {icon}
+        </IconButton>
+      </Tooltip>
+    </Box>
+  );
+};
 export default FloatButton;

--- a/src/manager/components/ManagerToaster.tsx
+++ b/src/manager/components/ManagerToaster.tsx
@@ -1,6 +1,5 @@
 import { Toaster } from "sonner";
 import { Theme } from "../../types/backend";
-import { memo } from "react";
 
 interface ManagerToasterProps {
   /** The theme. */
@@ -13,7 +12,7 @@ interface ManagerToasterProps {
  * This is styled on top of [`Toaster`](https://sonner.emilkowal.ski/toaster), rendered
  * in the bottom center of the manager window.
  */
-const ManagerToaster = memo(({ theme }: ManagerToasterProps) => {
+const ManagerToaster = ({ theme }: ManagerToasterProps) => {
   return (
     <Toaster
       position="bottom-center"
@@ -29,6 +28,6 @@ const ManagerToaster = memo(({ theme }: ManagerToasterProps) => {
       }}
     />
   );
-});
+};
 
 export default ManagerToaster;

--- a/src/manager/components/ManagerToaster.tsx
+++ b/src/manager/components/ManagerToaster.tsx
@@ -1,7 +1,8 @@
 import { Toaster } from "sonner";
 import { Theme } from "../../types/backend";
+import { memo } from "react";
 
-export interface ManagerToasterProps {
+interface ManagerToasterProps {
   /** The theme. */
   theme: Theme;
 }
@@ -12,7 +13,7 @@ export interface ManagerToasterProps {
  * This is styled on top of [`Toaster`](https://sonner.emilkowal.ski/toaster), rendered
  * in the bottom center of the manager window.
  */
-export default function ManagerToaster({ theme }: ManagerToasterProps) {
+const ManagerToaster = memo(({ theme }: ManagerToasterProps) => {
   return (
     <Toaster
       position="bottom-center"
@@ -28,4 +29,6 @@ export default function ManagerToaster({ theme }: ManagerToasterProps) {
       }}
     />
   );
-}
+});
+
+export default ManagerToaster;

--- a/src/manager/components/NumberInput.tsx
+++ b/src/manager/components/NumberInput.tsx
@@ -1,6 +1,6 @@
-import { ChangeEvent } from "react";
+import { ChangeEvent, memo } from "react";
 
-export interface NumberInputProps {
+interface NumberInputProps {
   /** The controlled number input value. */
   value: number;
   /** The callback on value change. */
@@ -25,45 +25,43 @@ export interface NumberInputProps {
  * such that it has the increment/decrement buttons, accepts keyboard input, reacts to
  * up/down keys and the scroll wheel, etc.
  */
-export default function NumberInput({
-  value,
-  onChange,
-  min,
-  max,
-  width,
-}: NumberInputProps) {
-  function handleChange(event: ChangeEvent<HTMLInputElement>) {
-    if (event.target.value === "") {
-      onChange(min ?? 0);
-      return;
+const NumberInput = memo(
+  ({ value, onChange, min, max, width }: NumberInputProps) => {
+    function handleChange(event: ChangeEvent<HTMLInputElement>) {
+      if (event.target.value === "") {
+        onChange(min ?? 0);
+        return;
+      }
+
+      const value = parseInt(event.target.value, 10);
+      if (min !== undefined && value < min) {
+        onChange(min);
+        return;
+      }
+      if (max !== undefined && value > max) {
+        onChange(max);
+        return;
+      }
+      onChange(value);
     }
 
-    const value = parseInt(event.target.value, 10);
-    if (min !== undefined && value < min) {
-      onChange(min);
-      return;
-    }
-    if (max !== undefined && value > max) {
-      onChange(max);
-      return;
-    }
-    onChange(value);
-  }
+    return (
+      <input
+        type="number"
+        value={value.toFixed(0)}
+        onChange={handleChange}
+        css={{
+          all: "unset",
+          backgroundColor: "var(--gray-5)",
+          paddingLeft: "var(--space-2)",
+          fontSize: "var(--font-size-2)",
+          lineHeight: 1.6,
+          borderRadius: "var(--radius-2)",
+          width,
+        }}
+      />
+    );
+  },
+);
 
-  return (
-    <input
-      type="number"
-      value={value.toFixed(0)}
-      onChange={handleChange}
-      css={{
-        all: "unset",
-        backgroundColor: "var(--gray-5)",
-        paddingLeft: "var(--space-2)",
-        fontSize: "var(--font-size-2)",
-        lineHeight: 1.6,
-        borderRadius: "var(--radius-2)",
-        width,
-      }}
-    />
-  );
-}
+export default NumberInput;

--- a/src/manager/components/NumberInput.tsx
+++ b/src/manager/components/NumberInput.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, memo } from "react";
+import { ChangeEvent } from "react";
 
 interface NumberInputProps {
   /** The controlled number input value. */
@@ -25,43 +25,47 @@ interface NumberInputProps {
  * such that it has the increment/decrement buttons, accepts keyboard input, reacts to
  * up/down keys and the scroll wheel, etc.
  */
-const NumberInput = memo(
-  ({ value, onChange, min, max, width }: NumberInputProps) => {
-    function handleChange(event: ChangeEvent<HTMLInputElement>) {
-      if (event.target.value === "") {
-        onChange(min ?? 0);
-        return;
-      }
-
-      const value = parseInt(event.target.value, 10);
-      if (min !== undefined && value < min) {
-        onChange(min);
-        return;
-      }
-      if (max !== undefined && value > max) {
-        onChange(max);
-        return;
-      }
-      onChange(value);
+const NumberInput = ({
+  value,
+  onChange,
+  min,
+  max,
+  width,
+}: NumberInputProps) => {
+  function handleChange(event: ChangeEvent<HTMLInputElement>) {
+    if (event.target.value === "") {
+      onChange(min ?? 0);
+      return;
     }
 
-    return (
-      <input
-        type="number"
-        value={value.toFixed(0)}
-        onChange={handleChange}
-        css={{
-          all: "unset",
-          backgroundColor: "var(--gray-5)",
-          paddingLeft: "var(--space-2)",
-          fontSize: "var(--font-size-2)",
-          lineHeight: 1.6,
-          borderRadius: "var(--radius-2)",
-          width,
-        }}
-      />
-    );
-  },
-);
+    const value = parseInt(event.target.value, 10);
+    if (min !== undefined && value < min) {
+      onChange(min);
+      return;
+    }
+    if (max !== undefined && value > max) {
+      onChange(max);
+      return;
+    }
+    onChange(value);
+  }
+
+  return (
+    <input
+      type="number"
+      value={value.toFixed(0)}
+      onChange={handleChange}
+      css={{
+        all: "unset",
+        backgroundColor: "var(--gray-5)",
+        paddingLeft: "var(--space-2)",
+        fontSize: "var(--font-size-2)",
+        lineHeight: 1.6,
+        borderRadius: "var(--radius-2)",
+        width,
+      }}
+    />
+  );
+};
 
 export default NumberInput;

--- a/src/manager/components/SettingToggleShortcut.tsx
+++ b/src/manager/components/SettingToggleShortcut.tsx
@@ -9,12 +9,12 @@ import {
   Strong,
   Text,
 } from "@radix-ui/themes";
-import { Dispatch, SetStateAction, useEffect, useState } from "react";
+import { Dispatch, SetStateAction, memo, useEffect, useState } from "react";
 import Shortcut from "./Shortcut";
 import { FaEdit } from "react-icons/fa";
 import useKeyboardListener from "../hooks/useKeyboardListener";
 
-export interface SettingToggleShortcutProps {
+interface SettingToggleShortcutProps {
   /** Setter for the toggle shortcut state. */
   setToggleShortcut: Dispatch<SetStateAction<string | null>>;
 }
@@ -40,160 +40,162 @@ export interface SettingToggleShortcutProps {
  *   within the popover will be reset to initial. The actual shortcut will not be
  *   touched.
  */
-export default function SettingToggleShortcut({
-  setToggleShortcut,
-}: SettingToggleShortcutProps) {
-  const [popoverOpen, setPopoverOpen] = useState(false);
-  const [disableShortcut, setDisableShortcut] = useState(false);
+const SettingToggleShortcut = memo(
+  ({ setToggleShortcut }: SettingToggleShortcutProps) => {
+    const [popoverOpen, setPopoverOpen] = useState(false);
+    const [disableShortcut, setDisableShortcut] = useState(false);
 
-  const {
-    listeningToShortcut,
-    setListeningToShortcut,
-    listenedShortcut,
-    hasModifier,
-    hasKey,
-    cleanup,
-  } = useKeyboardListener();
+    const {
+      listeningToShortcut,
+      setListeningToShortcut,
+      listenedShortcut,
+      hasModifier,
+      hasKey,
+      cleanup,
+    } = useKeyboardListener();
 
-  // Cleanup when shortcut changes from enabled to disabled
-  useEffect(() => {
-    if (disableShortcut) {
+    // Cleanup when shortcut changes from enabled to disabled
+    useEffect(() => {
+      if (disableShortcut) {
+        cleanup();
+      }
+    }, [disableShortcut, cleanup]);
+
+    // Cleanup and reset states when popover is opened/closed
+    useEffect(() => {
+      setDisableShortcut(false);
       cleanup();
-    }
-  }, [disableShortcut, cleanup]);
+    }, [popoverOpen, cleanup]);
 
-  // Cleanup and reset states when popover is opened/closed
-  useEffect(() => {
-    setDisableShortcut(false);
-    cleanup();
-  }, [popoverOpen, cleanup]);
-
-  return (
-    <Popover.Root
-      open={popoverOpen}
-      onOpenChange={(isOpen) => setPopoverOpen(isOpen)}
-    >
-      <Popover.Trigger>
-        <Button
-          size="1"
-          variant="surface"
-          color="gray"
-          highContrast
-          onClick={() => setPopoverOpen(true)}
-        >
-          <FaEdit /> Edit
-        </Button>
-      </Popover.Trigger>
-      <Popover.Content
-        side="left"
-        size="1"
-        width="500px"
-        onInteractOutside={(e) => e.preventDefault()}
-        onPointerDownOutside={(e) => e.preventDefault()}
-        onFocusOutside={(e) => e.preventDefault()}
-        asChild
+    return (
+      <Popover.Root
+        open={popoverOpen}
+        onOpenChange={(isOpen) => setPopoverOpen(isOpen)}
       >
-        <Flex direction="column" gap="3">
-          {/* Introduction */}
-          <Blockquote size="1" color="gray">
-            The toggle shortcut is used for toggling the floating/sinking state
-            of the canvas, equivalent to the &quot;Float/Sink&quot; option in
-            the tray menu. Widgets are not interactable when the canvas is
-            floated, and the desktop is not interactable when the canvas is
-            sunk.
-          </Blockquote>
-          {/* Decision whether to disable the shortcut */}
-          <Text size="1">
-            <Flex gap="2" align="center">
-              <Checkbox
-                size="1"
-                checked={disableShortcut}
-                onCheckedChange={(checked) => {
-                  setDisableShortcut(
-                    checked === "indeterminate" ? true : checked,
-                  );
+        <Popover.Trigger>
+          <Button
+            size="1"
+            variant="surface"
+            color="gray"
+            highContrast
+            onClick={() => setPopoverOpen(true)}
+          >
+            <FaEdit /> Edit
+          </Button>
+        </Popover.Trigger>
+        <Popover.Content
+          side="left"
+          size="1"
+          width="500px"
+          onInteractOutside={(e) => e.preventDefault()}
+          onPointerDownOutside={(e) => e.preventDefault()}
+          onFocusOutside={(e) => e.preventDefault()}
+          asChild
+        >
+          <Flex direction="column" gap="3">
+            {/* Introduction */}
+            <Blockquote size="1" color="gray">
+              The toggle shortcut is used for toggling the floating/sinking
+              state of the canvas, equivalent to the &quot;Float/Sink&quot;
+              option in the tray menu. Widgets are not interactable when the
+              canvas is floated, and the desktop is not interactable when the
+              canvas is sunk.
+            </Blockquote>
+            {/* Decision whether to disable the shortcut */}
+            <Text size="1">
+              <Flex gap="2" align="center">
+                <Checkbox
+                  size="1"
+                  checked={disableShortcut}
+                  onCheckedChange={(checked) => {
+                    setDisableShortcut(
+                      checked === "indeterminate" ? true : checked,
+                    );
+                  }}
+                />
+                <Text>
+                  Disable the toggle shortcut.{" "}
+                  <Em>Use the tray to float/sink the canvas instead.</Em>
+                </Text>
+              </Flex>
+            </Text>
+            {/* Usage guidance */}
+            <Text size="1">
+              Start by clicking the <Strong>Start Listening</Strong> button and
+              pressing the desired shortcut.
+            </Text>
+            {/* Shortcut setting panel */}
+            {!disableShortcut && (
+              <Shortcut
+                keys={listenedShortcut}
+                height="100px"
+                justify="center"
+                gap="3"
+                size="3"
+                css={{
+                  borderRadius: "var(--radius-2)",
+                  backgroundImage: `url("data:image/svg+xml,%3Csvg width='6' height='6' viewBox='0 0 6 6' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='%239C92AC' fill-opacity='0.2' fill-rule='evenodd'%3E%3Cpath d='M5 0h1L0 6V5zM6 5v1H5z'/%3E%3C/g%3E%3C/svg%3E")`,
                 }}
               />
-              <Text>
-                Disable the toggle shortcut.{" "}
-                <Em>Use the tray to float/sink the canvas instead.</Em>
-              </Text>
-            </Flex>
-          </Text>
-          {/* Usage guidance */}
-          <Text size="1">
-            Start by clicking the <Strong>Start Listening</Strong> button and
-            pressing the desired shortcut.
-          </Text>
-          {/* Shortcut setting panel */}
-          {!disableShortcut && (
-            <Shortcut
-              keys={listenedShortcut}
-              height="100px"
-              justify="center"
-              gap="3"
-              size="3"
-              css={{
-                borderRadius: "var(--radius-2)",
-                backgroundImage: `url("data:image/svg+xml,%3Csvg width='6' height='6' viewBox='0 0 6 6' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='%239C92AC' fill-opacity='0.2' fill-rule='evenodd'%3E%3Cpath d='M5 0h1L0 6V5zM6 5v1H5z'/%3E%3C/g%3E%3C/svg%3E")`,
-              }}
-            />
-          )}
-          {/* Action buttons */}
-          <Flex justify="end" gap="2">
-            {!disableShortcut && (
+            )}
+            {/* Action buttons */}
+            <Flex justify="end" gap="2">
+              {!disableShortcut && (
+                <Button
+                  size="1"
+                  variant="surface"
+                  color="gray"
+                  highContrast
+                  onClick={() => {
+                    setListeningToShortcut((prev) => !prev);
+                  }}
+                >
+                  {listeningToShortcut ? "Stop listening" : "Start listening"}
+                </Button>
+              )}
               <Button
                 size="1"
                 variant="surface"
                 color="gray"
                 highContrast
+                disabled={!disableShortcut && (!hasModifier || !hasKey)}
                 onClick={() => {
-                  setListeningToShortcut((prev) => !prev);
+                  setToggleShortcut(
+                    disableShortcut ? null : listenedShortcut.join("+"),
+                  );
+                  setPopoverOpen(false);
                 }}
               >
-                {listeningToShortcut ? "Stop listening" : "Start listening"}
+                Confirm
               </Button>
-            )}
-            <Button
-              size="1"
-              variant="surface"
-              color="gray"
-              highContrast
-              disabled={!disableShortcut && (!hasModifier || !hasKey)}
-              onClick={() => {
-                setToggleShortcut(
-                  disableShortcut ? null : listenedShortcut.join("+"),
-                );
-                setPopoverOpen(false);
-              }}
-            >
-              Confirm
-            </Button>
-            <Popover.Close>
-              <Button size="1" variant="surface" color="red">
-                Cancel
-              </Button>
-            </Popover.Close>
-          </Flex>
-          {/* Real-time validation messages */}
-          {!disableShortcut && (
-            <Flex direction="column" gap="1">
-              {!hasModifier && (
-                <Text size="1">
-                  <Badge color="red">Invalid</Badge> Shortcut must contain at
-                  least one modifier.
-                </Text>
-              )}
-              {!hasKey && (
-                <Text size="1">
-                  <Badge color="red">Invalid</Badge> Shortcut must contain an
-                  alphanumerical main key.
-                </Text>
-              )}
+              <Popover.Close>
+                <Button size="1" variant="surface" color="red">
+                  Cancel
+                </Button>
+              </Popover.Close>
             </Flex>
-          )}
-        </Flex>
-      </Popover.Content>
-    </Popover.Root>
-  );
-}
+            {/* Real-time validation messages */}
+            {!disableShortcut && (
+              <Flex direction="column" gap="1">
+                {!hasModifier && (
+                  <Text size="1">
+                    <Badge color="red">Invalid</Badge> Shortcut must contain at
+                    least one modifier.
+                  </Text>
+                )}
+                {!hasKey && (
+                  <Text size="1">
+                    <Badge color="red">Invalid</Badge> Shortcut must contain an
+                    alphanumerical main key.
+                  </Text>
+                )}
+              </Flex>
+            )}
+          </Flex>
+        </Popover.Content>
+      </Popover.Root>
+    );
+  },
+);
+
+export default SettingToggleShortcut;

--- a/src/manager/components/SettingToggleShortcut.tsx
+++ b/src/manager/components/SettingToggleShortcut.tsx
@@ -9,7 +9,7 @@ import {
   Strong,
   Text,
 } from "@radix-ui/themes";
-import { Dispatch, SetStateAction, memo, useEffect, useState } from "react";
+import { Dispatch, SetStateAction, useEffect, useState } from "react";
 import Shortcut from "./Shortcut";
 import { FaEdit } from "react-icons/fa";
 import useKeyboardListener from "../hooks/useKeyboardListener";
@@ -40,162 +40,162 @@ interface SettingToggleShortcutProps {
  *   within the popover will be reset to initial. The actual shortcut will not be
  *   touched.
  */
-const SettingToggleShortcut = memo(
-  ({ setToggleShortcut }: SettingToggleShortcutProps) => {
-    const [popoverOpen, setPopoverOpen] = useState(false);
-    const [disableShortcut, setDisableShortcut] = useState(false);
+const SettingToggleShortcut = ({
+  setToggleShortcut,
+}: SettingToggleShortcutProps) => {
+  const [popoverOpen, setPopoverOpen] = useState(false);
+  const [disableShortcut, setDisableShortcut] = useState(false);
 
-    const {
-      listeningToShortcut,
-      setListeningToShortcut,
-      listenedShortcut,
-      hasModifier,
-      hasKey,
-      cleanup,
-    } = useKeyboardListener();
+  const {
+    listeningToShortcut,
+    setListeningToShortcut,
+    listenedShortcut,
+    hasModifier,
+    hasKey,
+    cleanup,
+  } = useKeyboardListener();
 
-    // Cleanup when shortcut changes from enabled to disabled
-    useEffect(() => {
-      if (disableShortcut) {
-        cleanup();
-      }
-    }, [disableShortcut, cleanup]);
-
-    // Cleanup and reset states when popover is opened/closed
-    useEffect(() => {
-      setDisableShortcut(false);
+  // Cleanup when shortcut changes from enabled to disabled
+  useEffect(() => {
+    if (disableShortcut) {
       cleanup();
-    }, [popoverOpen, cleanup]);
+    }
+  }, [disableShortcut, cleanup]);
 
-    return (
-      <Popover.Root
-        open={popoverOpen}
-        onOpenChange={(isOpen) => setPopoverOpen(isOpen)}
-      >
-        <Popover.Trigger>
-          <Button
-            size="1"
-            variant="surface"
-            color="gray"
-            highContrast
-            onClick={() => setPopoverOpen(true)}
-          >
-            <FaEdit /> Edit
-          </Button>
-        </Popover.Trigger>
-        <Popover.Content
-          side="left"
+  // Cleanup and reset states when popover is opened/closed
+  useEffect(() => {
+    setDisableShortcut(false);
+    cleanup();
+  }, [popoverOpen, cleanup]);
+
+  return (
+    <Popover.Root
+      open={popoverOpen}
+      onOpenChange={(isOpen) => setPopoverOpen(isOpen)}
+    >
+      <Popover.Trigger>
+        <Button
           size="1"
-          width="500px"
-          onInteractOutside={(e) => e.preventDefault()}
-          onPointerDownOutside={(e) => e.preventDefault()}
-          onFocusOutside={(e) => e.preventDefault()}
-          asChild
+          variant="surface"
+          color="gray"
+          highContrast
+          onClick={() => setPopoverOpen(true)}
         >
-          <Flex direction="column" gap="3">
-            {/* Introduction */}
-            <Blockquote size="1" color="gray">
-              The toggle shortcut is used for toggling the floating/sinking
-              state of the canvas, equivalent to the &quot;Float/Sink&quot;
-              option in the tray menu. Widgets are not interactable when the
-              canvas is floated, and the desktop is not interactable when the
-              canvas is sunk.
-            </Blockquote>
-            {/* Decision whether to disable the shortcut */}
-            <Text size="1">
-              <Flex gap="2" align="center">
-                <Checkbox
-                  size="1"
-                  checked={disableShortcut}
-                  onCheckedChange={(checked) => {
-                    setDisableShortcut(
-                      checked === "indeterminate" ? true : checked,
-                    );
-                  }}
-                />
-                <Text>
-                  Disable the toggle shortcut.{" "}
-                  <Em>Use the tray to float/sink the canvas instead.</Em>
-                </Text>
-              </Flex>
-            </Text>
-            {/* Usage guidance */}
-            <Text size="1">
-              Start by clicking the <Strong>Start Listening</Strong> button and
-              pressing the desired shortcut.
-            </Text>
-            {/* Shortcut setting panel */}
-            {!disableShortcut && (
-              <Shortcut
-                keys={listenedShortcut}
-                height="100px"
-                justify="center"
-                gap="3"
-                size="3"
-                css={{
-                  borderRadius: "var(--radius-2)",
-                  backgroundImage: `url("data:image/svg+xml,%3Csvg width='6' height='6' viewBox='0 0 6 6' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='%239C92AC' fill-opacity='0.2' fill-rule='evenodd'%3E%3Cpath d='M5 0h1L0 6V5zM6 5v1H5z'/%3E%3C/g%3E%3C/svg%3E")`,
+          <FaEdit /> Edit
+        </Button>
+      </Popover.Trigger>
+      <Popover.Content
+        side="left"
+        size="1"
+        width="500px"
+        onInteractOutside={(e) => e.preventDefault()}
+        onPointerDownOutside={(e) => e.preventDefault()}
+        onFocusOutside={(e) => e.preventDefault()}
+        asChild
+      >
+        <Flex direction="column" gap="3">
+          {/* Introduction */}
+          <Blockquote size="1" color="gray">
+            The toggle shortcut is used for toggling the floating/sinking state
+            of the canvas, equivalent to the &quot;Float/Sink&quot; option in
+            the tray menu. Widgets are not interactable when the canvas is
+            floated, and the desktop is not interactable when the canvas is
+            sunk.
+          </Blockquote>
+          {/* Decision whether to disable the shortcut */}
+          <Text size="1">
+            <Flex gap="2" align="center">
+              <Checkbox
+                size="1"
+                checked={disableShortcut}
+                onCheckedChange={(checked) => {
+                  setDisableShortcut(
+                    checked === "indeterminate" ? true : checked,
+                  );
                 }}
               />
-            )}
-            {/* Action buttons */}
-            <Flex justify="end" gap="2">
-              {!disableShortcut && (
-                <Button
-                  size="1"
-                  variant="surface"
-                  color="gray"
-                  highContrast
-                  onClick={() => {
-                    setListeningToShortcut((prev) => !prev);
-                  }}
-                >
-                  {listeningToShortcut ? "Stop listening" : "Start listening"}
-                </Button>
-              )}
+              <Text>
+                Disable the toggle shortcut.{" "}
+                <Em>Use the tray to float/sink the canvas instead.</Em>
+              </Text>
+            </Flex>
+          </Text>
+          {/* Usage guidance */}
+          <Text size="1">
+            Start by clicking the <Strong>Start Listening</Strong> button and
+            pressing the desired shortcut.
+          </Text>
+          {/* Shortcut setting panel */}
+          {!disableShortcut && (
+            <Shortcut
+              keys={listenedShortcut}
+              height="100px"
+              justify="center"
+              gap="3"
+              size="3"
+              css={{
+                borderRadius: "var(--radius-2)",
+                backgroundImage: `url("data:image/svg+xml,%3Csvg width='6' height='6' viewBox='0 0 6 6' xmlns='http://www.w3.org/2000/svg'%3E%3Cg fill='%239C92AC' fill-opacity='0.2' fill-rule='evenodd'%3E%3Cpath d='M5 0h1L0 6V5zM6 5v1H5z'/%3E%3C/g%3E%3C/svg%3E")`,
+              }}
+            />
+          )}
+          {/* Action buttons */}
+          <Flex justify="end" gap="2">
+            {!disableShortcut && (
               <Button
                 size="1"
                 variant="surface"
                 color="gray"
                 highContrast
-                disabled={!disableShortcut && (!hasModifier || !hasKey)}
                 onClick={() => {
-                  setToggleShortcut(
-                    disableShortcut ? null : listenedShortcut.join("+"),
-                  );
-                  setPopoverOpen(false);
+                  setListeningToShortcut((prev) => !prev);
                 }}
               >
-                Confirm
+                {listeningToShortcut ? "Stop listening" : "Start listening"}
               </Button>
-              <Popover.Close>
-                <Button size="1" variant="surface" color="red">
-                  Cancel
-                </Button>
-              </Popover.Close>
-            </Flex>
-            {/* Real-time validation messages */}
-            {!disableShortcut && (
-              <Flex direction="column" gap="1">
-                {!hasModifier && (
-                  <Text size="1">
-                    <Badge color="red">Invalid</Badge> Shortcut must contain at
-                    least one modifier.
-                  </Text>
-                )}
-                {!hasKey && (
-                  <Text size="1">
-                    <Badge color="red">Invalid</Badge> Shortcut must contain an
-                    alphanumerical main key.
-                  </Text>
-                )}
-              </Flex>
             )}
+            <Button
+              size="1"
+              variant="surface"
+              color="gray"
+              highContrast
+              disabled={!disableShortcut && (!hasModifier || !hasKey)}
+              onClick={() => {
+                setToggleShortcut(
+                  disableShortcut ? null : listenedShortcut.join("+"),
+                );
+                setPopoverOpen(false);
+              }}
+            >
+              Confirm
+            </Button>
+            <Popover.Close>
+              <Button size="1" variant="surface" color="red">
+                Cancel
+              </Button>
+            </Popover.Close>
           </Flex>
-        </Popover.Content>
-      </Popover.Root>
-    );
-  },
-);
+          {/* Real-time validation messages */}
+          {!disableShortcut && (
+            <Flex direction="column" gap="1">
+              {!hasModifier && (
+                <Text size="1">
+                  <Badge color="red">Invalid</Badge> Shortcut must contain at
+                  least one modifier.
+                </Text>
+              )}
+              {!hasKey && (
+                <Text size="1">
+                  <Badge color="red">Invalid</Badge> Shortcut must contain an
+                  alphanumerical main key.
+                </Text>
+              )}
+            </Flex>
+          )}
+        </Flex>
+      </Popover.Content>
+    </Popover.Root>
+  );
+};
 
 export default SettingToggleShortcut;

--- a/src/manager/components/Shortcut.tsx
+++ b/src/manager/components/Shortcut.tsx
@@ -1,5 +1,5 @@
 import { Flex, Kbd, KbdProps, Text } from "@radix-ui/themes";
-import { ComponentPropsWithoutRef, Fragment, memo } from "react";
+import { ComponentPropsWithoutRef, Fragment } from "react";
 
 interface ShortcutProps {
   /** The array of shortcut keys. */
@@ -15,31 +15,29 @@ interface ShortcutProps {
  * wrapped in a flex box with default gap size 1. All flex box props can be passed to
  * this component to further customize the display layout.
  */
-const Shortcut = memo(
-  ({
-    keys,
-    size = "2",
-    ...props
-  }: ShortcutProps & ComponentPropsWithoutRef<typeof Flex>) => {
-    return (
-      <Flex align="center" gap="1" {...props}>
-        {keys.length > 0 ? (
-          <Kbd size={size}>{keys[0]}</Kbd>
-        ) : (
-          <Text size={size}>None</Text>
-        )}
-        {keys.map(
-          (key, index) =>
-            index !== 0 && (
-              <Fragment key={key}>
-                <Text size={size}>+</Text>
-                <Kbd size={size}>{key}</Kbd>
-              </Fragment>
-            ),
-        )}
-      </Flex>
-    );
-  },
-);
+const Shortcut = ({
+  keys,
+  size = "2",
+  ...props
+}: ShortcutProps & ComponentPropsWithoutRef<typeof Flex>) => {
+  return (
+    <Flex align="center" gap="1" {...props}>
+      {keys.length > 0 ? (
+        <Kbd size={size}>{keys[0]}</Kbd>
+      ) : (
+        <Text size={size}>None</Text>
+      )}
+      {keys.map(
+        (key, index) =>
+          index !== 0 && (
+            <Fragment key={key}>
+              <Text size={size}>+</Text>
+              <Kbd size={size}>{key}</Kbd>
+            </Fragment>
+          ),
+      )}
+    </Flex>
+  );
+};
 
 export default Shortcut;

--- a/src/manager/components/Shortcut.tsx
+++ b/src/manager/components/Shortcut.tsx
@@ -1,7 +1,7 @@
 import { Flex, Kbd, KbdProps, Text } from "@radix-ui/themes";
-import { ComponentPropsWithoutRef, Fragment } from "react";
+import { ComponentPropsWithoutRef, Fragment, memo } from "react";
 
-export interface ShortcutProps {
+interface ShortcutProps {
   /** The array of shortcut keys. */
   keys: string[];
   /** The size of the shortcut display. */
@@ -15,27 +15,31 @@ export interface ShortcutProps {
  * wrapped in a flex box with default gap size 1. All flex box props can be passed to
  * this component to further customize the display layout.
  */
-export default function Shortcut({
-  keys,
-  size = "2",
-  ...props
-}: ShortcutProps & ComponentPropsWithoutRef<typeof Flex>) {
-  return (
-    <Flex align="center" gap="1" {...props}>
-      {keys.length > 0 ? (
-        <Kbd size={size}>{keys[0]}</Kbd>
-      ) : (
-        <Text size={size}>None</Text>
-      )}
-      {keys.map(
-        (key, index) =>
-          index !== 0 && (
-            <Fragment key={key}>
-              <Text size={size}>+</Text>
-              <Kbd size={size}>{key}</Kbd>
-            </Fragment>
-          ),
-      )}
-    </Flex>
-  );
-}
+const Shortcut = memo(
+  ({
+    keys,
+    size = "2",
+    ...props
+  }: ShortcutProps & ComponentPropsWithoutRef<typeof Flex>) => {
+    return (
+      <Flex align="center" gap="1" {...props}>
+        {keys.length > 0 ? (
+          <Kbd size={size}>{keys[0]}</Kbd>
+        ) : (
+          <Text size={size}>None</Text>
+        )}
+        {keys.map(
+          (key, index) =>
+            index !== 0 && (
+              <Fragment key={key}>
+                <Text size={size}>+</Text>
+                <Kbd size={size}>{key}</Kbd>
+              </Fragment>
+            ),
+        )}
+      </Flex>
+    );
+  },
+);
+
+export default Shortcut;

--- a/src/manager/components/ThemeToggler.tsx
+++ b/src/manager/components/ThemeToggler.tsx
@@ -1,7 +1,7 @@
 import { Box, IconButton, Tooltip } from "@radix-ui/themes";
 import { Theme } from "../../types/backend";
 import { MdOutlineDarkMode, MdOutlineLightMode } from "react-icons/md";
-import { Dispatch, SetStateAction, memo } from "react";
+import { Dispatch, SetStateAction } from "react";
 import { emitSwitchThemeToCanvas } from "../../events";
 
 interface AppearanceTogglerProps {
@@ -18,31 +18,29 @@ interface AppearanceTogglerProps {
  * window. Clicking the icon button should switch the theme appearance between light
  * and dark mode. The tooltip and icon should reflect the current theme appearance.
  */
-const AppearanceToggler = memo(
-  ({ theme, setTheme }: AppearanceTogglerProps) => {
-    const toggleTheme = () => {
-      const newTheme = theme === Theme.LIGHT ? Theme.DARK : Theme.LIGHT;
-      setTheme(newTheme);
-      emitSwitchThemeToCanvas(newTheme).catch(console.error);
-    };
+const AppearanceToggler = ({ theme, setTheme }: AppearanceTogglerProps) => {
+  const toggleTheme = () => {
+    const newTheme = theme === Theme.LIGHT ? Theme.DARK : Theme.LIGHT;
+    setTheme(newTheme);
+    emitSwitchThemeToCanvas(newTheme).catch(console.error);
+  };
 
-    return (
-      <Box position="absolute" right="3" top="4">
-        <Tooltip
-          side="left"
-          content={`Switch to ${theme === Theme.LIGHT ? Theme.DARK : Theme.LIGHT} mode`}
-        >
-          <IconButton variant="soft" size="1" onClick={toggleTheme}>
-            {theme === Theme.LIGHT ? (
-              <MdOutlineLightMode />
-            ) : (
-              <MdOutlineDarkMode />
-            )}
-          </IconButton>
-        </Tooltip>
-      </Box>
-    );
-  },
-);
+  return (
+    <Box position="absolute" right="3" top="4">
+      <Tooltip
+        side="left"
+        content={`Switch to ${theme === Theme.LIGHT ? Theme.DARK : Theme.LIGHT} mode`}
+      >
+        <IconButton variant="soft" size="1" onClick={toggleTheme}>
+          {theme === Theme.LIGHT ? (
+            <MdOutlineLightMode />
+          ) : (
+            <MdOutlineDarkMode />
+          )}
+        </IconButton>
+      </Tooltip>
+    </Box>
+  );
+};
 
 export default AppearanceToggler;

--- a/src/manager/components/ThemeToggler.tsx
+++ b/src/manager/components/ThemeToggler.tsx
@@ -1,10 +1,10 @@
 import { Box, IconButton, Tooltip } from "@radix-ui/themes";
 import { Theme } from "../../types/backend";
 import { MdOutlineDarkMode, MdOutlineLightMode } from "react-icons/md";
-import { Dispatch, SetStateAction } from "react";
+import { Dispatch, SetStateAction, memo } from "react";
 import { emitSwitchThemeToCanvas } from "../../events";
 
-export interface AppearanceTogglerProps {
+interface AppearanceTogglerProps {
   /** Theme. */
   theme: Theme;
   /** State for theme. */
@@ -18,30 +18,31 @@ export interface AppearanceTogglerProps {
  * window. Clicking the icon button should switch the theme appearance between light
  * and dark mode. The tooltip and icon should reflect the current theme appearance.
  */
-export default function AppearanceToggler({
-  theme,
-  setTheme,
-}: AppearanceTogglerProps) {
-  const toggleTheme = () => {
-    const newTheme = theme === Theme.LIGHT ? Theme.DARK : Theme.LIGHT;
-    setTheme(newTheme);
-    emitSwitchThemeToCanvas(newTheme).catch(console.error);
-  };
+const AppearanceToggler = memo(
+  ({ theme, setTheme }: AppearanceTogglerProps) => {
+    const toggleTheme = () => {
+      const newTheme = theme === Theme.LIGHT ? Theme.DARK : Theme.LIGHT;
+      setTheme(newTheme);
+      emitSwitchThemeToCanvas(newTheme).catch(console.error);
+    };
 
-  return (
-    <Box position="absolute" right="3" top="4">
-      <Tooltip
-        side="left"
-        content={`Switch to ${theme === Theme.LIGHT ? Theme.DARK : Theme.LIGHT} mode`}
-      >
-        <IconButton variant="soft" size="1" onClick={toggleTheme}>
-          {theme === Theme.LIGHT ? (
-            <MdOutlineLightMode />
-          ) : (
-            <MdOutlineDarkMode />
-          )}
-        </IconButton>
-      </Tooltip>
-    </Box>
-  );
-}
+    return (
+      <Box position="absolute" right="3" top="4">
+        <Tooltip
+          side="left"
+          content={`Switch to ${theme === Theme.LIGHT ? Theme.DARK : Theme.LIGHT} mode`}
+        >
+          <IconButton variant="soft" size="1" onClick={toggleTheme}>
+            {theme === Theme.LIGHT ? (
+              <MdOutlineLightMode />
+            ) : (
+              <MdOutlineDarkMode />
+            )}
+          </IconButton>
+        </Tooltip>
+      </Box>
+    );
+  },
+);
+
+export default AppearanceToggler;

--- a/src/manager/components/WidgetContent.tsx
+++ b/src/manager/components/WidgetContent.tsx
@@ -15,7 +15,7 @@ import {
   WidgetSettings,
 } from "../../types/backend";
 import { emitRenderWidgetToCanvas } from "../../events";
-import { Dispatch, SetStateAction, memo } from "react";
+import { Dispatch, SetStateAction } from "react";
 import { ManagerWidgetState } from "../../types/frontend";
 import WidgetContentHeading from "../components/WidgetContentHeading";
 import { toast } from "sonner";
@@ -44,69 +44,67 @@ interface WidgetContentProps {
  * {@link WidgetContentConfigList} and a setting section
  * {@link WidgetContentSettingsList}.
  */
-const WidgetContent = memo(
-  ({
-    index,
-    id,
-    config,
-    settings,
-    setManagerWidgetStates,
-  }: WidgetContentProps) => {
-    return (
-      <Tabs.Content value={`tab${index}`} asChild>
-        <Flex height="100%" gap="3" direction="column" css={{ flex: 3 }}>
-          <WidgetContentHeading
-            heading={
-              <Flex align="center" gap="2">
-                Configuration{" "}
-                {"Err" in config && <Badge color="red">Error</Badge>}
-              </Flex>
-            }
-            actionIcon={<LuFolderOpen />}
-            actionText="Edit"
-            action={() =>
-              invokeOpenInWidgetsDir({ components: [config.content.dir] })
-            }
-          />
-          <ScrollArea scrollbars="vertical" asChild>
-            <Box px="2" css={{ flex: 3 }}>
-              {config.type === WidgetConfigType.VALID ? (
-                <WidgetContentConfigList id={id} config={config} />
-              ) : (
-                <Text
-                  size="1"
-                  css={{
-                    whiteSpace: "pre-wrap",
-                    fontFamily: "var(--code-font-family)",
-                  }}
-                >
-                  {config.content.error}
-                </Text>
-              )}
-            </Box>
-          </ScrollArea>
-          <Separator size="4" />
-          <WidgetContentHeading
-            heading="Settings"
-            actionIcon={<LuRepeat />}
-            actionText="Re-render"
-            action={() =>
-              emitRenderWidgetToCanvas({ id, settings, bundle: true }).then(
-                () => toast.success(`Re-rendered widget "${id}".`),
-              )
-            }
-          />
-          <Box px="2" css={{ flex: 4 }}>
-            <WidgetContentSettingsList
-              id={id}
-              settings={settings}
-              setManagerWidgetStates={setManagerWidgetStates}
-            />
+const WidgetContent = ({
+  index,
+  id,
+  config,
+  settings,
+  setManagerWidgetStates,
+}: WidgetContentProps) => {
+  return (
+    <Tabs.Content value={`tab${index}`} asChild>
+      <Flex height="100%" gap="3" direction="column" css={{ flex: 3 }}>
+        <WidgetContentHeading
+          heading={
+            <Flex align="center" gap="2">
+              Configuration{" "}
+              {"Err" in config && <Badge color="red">Error</Badge>}
+            </Flex>
+          }
+          actionIcon={<LuFolderOpen />}
+          actionText="Edit"
+          action={() =>
+            invokeOpenInWidgetsDir({ components: [config.content.dir] })
+          }
+        />
+        <ScrollArea scrollbars="vertical" asChild>
+          <Box px="2" css={{ flex: 3 }}>
+            {config.type === WidgetConfigType.VALID ? (
+              <WidgetContentConfigList id={id} config={config} />
+            ) : (
+              <Text
+                size="1"
+                css={{
+                  whiteSpace: "pre-wrap",
+                  fontFamily: "var(--code-font-family)",
+                }}
+              >
+                {config.content.error}
+              </Text>
+            )}
           </Box>
-        </Flex>
-      </Tabs.Content>
-    );
-  },
-);
+        </ScrollArea>
+        <Separator size="4" />
+        <WidgetContentHeading
+          heading="Settings"
+          actionIcon={<LuRepeat />}
+          actionText="Re-render"
+          action={() =>
+            emitRenderWidgetToCanvas({ id, settings, bundle: true }).then(() =>
+              toast.success(`Re-rendered widget "${id}".`),
+            )
+          }
+        />
+        <Box px="2" css={{ flex: 4 }}>
+          <WidgetContentSettingsList
+            id={id}
+            settings={settings}
+            setManagerWidgetStates={setManagerWidgetStates}
+          />
+        </Box>
+      </Flex>
+    </Tabs.Content>
+  );
+};
 
 export default WidgetContent;

--- a/src/manager/components/WidgetContent.tsx
+++ b/src/manager/components/WidgetContent.tsx
@@ -15,14 +15,14 @@ import {
   WidgetSettings,
 } from "../../types/backend";
 import { emitRenderWidgetToCanvas } from "../../events";
-import { Dispatch, SetStateAction } from "react";
+import { Dispatch, SetStateAction, memo } from "react";
 import { ManagerWidgetState } from "../../types/frontend";
 import WidgetContentHeading from "../components/WidgetContentHeading";
 import { toast } from "sonner";
 import WidgetContentConfigList from "../components/WidgetContentConfigList";
 import WidgetContentSettingsList from "../components/WidgetContentSettingsList";
 
-export interface WidgetContentProps {
+interface WidgetContentProps {
   /** The index of the widget in the collection. */
   index: number;
   /** The widget ID. */
@@ -44,65 +44,69 @@ export interface WidgetContentProps {
  * {@link WidgetContentConfigList} and a setting section
  * {@link WidgetContentSettingsList}.
  */
-export default function WidgetContent({
-  index,
-  id,
-  config,
-  settings,
-  setManagerWidgetStates,
-}: WidgetContentProps) {
-  return (
-    <Tabs.Content value={`tab${index}`} asChild>
-      <Flex height="100%" gap="3" direction="column" css={{ flex: 3 }}>
-        <WidgetContentHeading
-          heading={
-            <Flex align="center" gap="2">
-              Configuration{" "}
-              {"Err" in config && <Badge color="red">Error</Badge>}
-            </Flex>
-          }
-          actionIcon={<LuFolderOpen />}
-          actionText="Edit"
-          action={() =>
-            invokeOpenInWidgetsDir({ components: [config.content.dir] })
-          }
-        />
-        <ScrollArea scrollbars="vertical" asChild>
-          <Box px="2" css={{ flex: 3 }}>
-            {config.type === WidgetConfigType.VALID ? (
-              <WidgetContentConfigList id={id} config={config} />
-            ) : (
-              <Text
-                size="1"
-                css={{
-                  whiteSpace: "pre-wrap",
-                  fontFamily: "var(--code-font-family)",
-                }}
-              >
-                {config.content.error}
-              </Text>
-            )}
-          </Box>
-        </ScrollArea>
-        <Separator size="4" />
-        <WidgetContentHeading
-          heading="Settings"
-          actionIcon={<LuRepeat />}
-          actionText="Re-render"
-          action={() =>
-            emitRenderWidgetToCanvas({ id, settings, bundle: true }).then(() =>
-              toast.success(`Re-rendered widget "${id}".`),
-            )
-          }
-        />
-        <Box px="2" css={{ flex: 4 }}>
-          <WidgetContentSettingsList
-            id={id}
-            settings={settings}
-            setManagerWidgetStates={setManagerWidgetStates}
+const WidgetContent = memo(
+  ({
+    index,
+    id,
+    config,
+    settings,
+    setManagerWidgetStates,
+  }: WidgetContentProps) => {
+    return (
+      <Tabs.Content value={`tab${index}`} asChild>
+        <Flex height="100%" gap="3" direction="column" css={{ flex: 3 }}>
+          <WidgetContentHeading
+            heading={
+              <Flex align="center" gap="2">
+                Configuration{" "}
+                {"Err" in config && <Badge color="red">Error</Badge>}
+              </Flex>
+            }
+            actionIcon={<LuFolderOpen />}
+            actionText="Edit"
+            action={() =>
+              invokeOpenInWidgetsDir({ components: [config.content.dir] })
+            }
           />
-        </Box>
-      </Flex>
-    </Tabs.Content>
-  );
-}
+          <ScrollArea scrollbars="vertical" asChild>
+            <Box px="2" css={{ flex: 3 }}>
+              {config.type === WidgetConfigType.VALID ? (
+                <WidgetContentConfigList id={id} config={config} />
+              ) : (
+                <Text
+                  size="1"
+                  css={{
+                    whiteSpace: "pre-wrap",
+                    fontFamily: "var(--code-font-family)",
+                  }}
+                >
+                  {config.content.error}
+                </Text>
+              )}
+            </Box>
+          </ScrollArea>
+          <Separator size="4" />
+          <WidgetContentHeading
+            heading="Settings"
+            actionIcon={<LuRepeat />}
+            actionText="Re-render"
+            action={() =>
+              emitRenderWidgetToCanvas({ id, settings, bundle: true }).then(
+                () => toast.success(`Re-rendered widget "${id}".`),
+              )
+            }
+          />
+          <Box px="2" css={{ flex: 4 }}>
+            <WidgetContentSettingsList
+              id={id}
+              settings={settings}
+              setManagerWidgetStates={setManagerWidgetStates}
+            />
+          </Box>
+        </Flex>
+      </Tabs.Content>
+    );
+  },
+);
+
+export default WidgetContent;

--- a/src/manager/components/WidgetContentConfigList.tsx
+++ b/src/manager/components/WidgetContentConfigList.tsx
@@ -3,8 +3,9 @@ import { WidgetConfig, WidgetConfigType } from "../../types/backend";
 import WidgetDependencies from "../components/WidgetDependencies";
 import { MdOpenInNew } from "react-icons/md";
 import { invokeOpenInWidgetsDir } from "../../commands";
+import { memo } from "react";
 
-export interface WidgetContentConfigListProps {
+interface WidgetContentConfigListProps {
   /** The widget ID. */
   id: string;
   /** The widget configuration. */
@@ -17,47 +18,48 @@ export interface WidgetContentConfigListProps {
  * This is rendered as a data list, displaying the widget ID, name, entry, and
  * external dependencies.
  */
-export default function WidgetContentConfigList({
-  id,
-  config,
-}: WidgetContentConfigListProps) {
-  return (
-    <DataList.Root size="2" css={{ gap: "var(--space-2)" }}>
-      <DataList.Item>
-        <DataList.Label>ID</DataList.Label>
-        <DataList.Value>{id}</DataList.Value>
-      </DataList.Item>
-      <DataList.Item>
-        <DataList.Label>Name</DataList.Label>
-        <DataList.Value>{config.content.name}</DataList.Value>
-      </DataList.Item>
-      <DataList.Item>
-        <DataList.Label>Entry</DataList.Label>
-        <DataList.Value>
-          <Flex align="center" gap="2">
-            <Code>{config.content.entry}</Code>
-            <Tooltip content="Open" side="right">
-              <IconButton
-                variant="ghost"
-                size="1"
-                onClick={() =>
-                  invokeOpenInWidgetsDir({
-                    components: [config.content.dir, config.content.entry],
-                  })
-                }
-              >
-                <MdOpenInNew />
-              </IconButton>
-            </Tooltip>
-          </Flex>
-        </DataList.Value>
-      </DataList.Item>
-      <DataList.Item>
-        <DataList.Label>Dependencies</DataList.Label>
-        <DataList.Value>
-          <WidgetDependencies dependencies={config.content.dependencies} />
-        </DataList.Value>
-      </DataList.Item>
-    </DataList.Root>
-  );
-}
+const WidgetContentConfigList = memo(
+  ({ id, config }: WidgetContentConfigListProps) => {
+    return (
+      <DataList.Root size="2" css={{ gap: "var(--space-2)" }}>
+        <DataList.Item>
+          <DataList.Label>ID</DataList.Label>
+          <DataList.Value>{id}</DataList.Value>
+        </DataList.Item>
+        <DataList.Item>
+          <DataList.Label>Name</DataList.Label>
+          <DataList.Value>{config.content.name}</DataList.Value>
+        </DataList.Item>
+        <DataList.Item>
+          <DataList.Label>Entry</DataList.Label>
+          <DataList.Value>
+            <Flex align="center" gap="2">
+              <Code>{config.content.entry}</Code>
+              <Tooltip content="Open" side="right">
+                <IconButton
+                  variant="ghost"
+                  size="1"
+                  onClick={() =>
+                    invokeOpenInWidgetsDir({
+                      components: [config.content.dir, config.content.entry],
+                    })
+                  }
+                >
+                  <MdOpenInNew />
+                </IconButton>
+              </Tooltip>
+            </Flex>
+          </DataList.Value>
+        </DataList.Item>
+        <DataList.Item>
+          <DataList.Label>Dependencies</DataList.Label>
+          <DataList.Value>
+            <WidgetDependencies dependencies={config.content.dependencies} />
+          </DataList.Value>
+        </DataList.Item>
+      </DataList.Root>
+    );
+  },
+);
+
+export default WidgetContentConfigList;

--- a/src/manager/components/WidgetContentConfigList.tsx
+++ b/src/manager/components/WidgetContentConfigList.tsx
@@ -3,7 +3,6 @@ import { WidgetConfig, WidgetConfigType } from "../../types/backend";
 import WidgetDependencies from "../components/WidgetDependencies";
 import { MdOpenInNew } from "react-icons/md";
 import { invokeOpenInWidgetsDir } from "../../commands";
-import { memo } from "react";
 
 interface WidgetContentConfigListProps {
   /** The widget ID. */
@@ -18,48 +17,49 @@ interface WidgetContentConfigListProps {
  * This is rendered as a data list, displaying the widget ID, name, entry, and
  * external dependencies.
  */
-const WidgetContentConfigList = memo(
-  ({ id, config }: WidgetContentConfigListProps) => {
-    return (
-      <DataList.Root size="2" css={{ gap: "var(--space-2)" }}>
-        <DataList.Item>
-          <DataList.Label>ID</DataList.Label>
-          <DataList.Value>{id}</DataList.Value>
-        </DataList.Item>
-        <DataList.Item>
-          <DataList.Label>Name</DataList.Label>
-          <DataList.Value>{config.content.name}</DataList.Value>
-        </DataList.Item>
-        <DataList.Item>
-          <DataList.Label>Entry</DataList.Label>
-          <DataList.Value>
-            <Flex align="center" gap="2">
-              <Code>{config.content.entry}</Code>
-              <Tooltip content="Open" side="right">
-                <IconButton
-                  variant="ghost"
-                  size="1"
-                  onClick={() =>
-                    invokeOpenInWidgetsDir({
-                      components: [config.content.dir, config.content.entry],
-                    })
-                  }
-                >
-                  <MdOpenInNew />
-                </IconButton>
-              </Tooltip>
-            </Flex>
-          </DataList.Value>
-        </DataList.Item>
-        <DataList.Item>
-          <DataList.Label>Dependencies</DataList.Label>
-          <DataList.Value>
-            <WidgetDependencies dependencies={config.content.dependencies} />
-          </DataList.Value>
-        </DataList.Item>
-      </DataList.Root>
-    );
-  },
-);
+const WidgetContentConfigList = ({
+  id,
+  config,
+}: WidgetContentConfigListProps) => {
+  return (
+    <DataList.Root size="2" css={{ gap: "var(--space-2)" }}>
+      <DataList.Item>
+        <DataList.Label>ID</DataList.Label>
+        <DataList.Value>{id}</DataList.Value>
+      </DataList.Item>
+      <DataList.Item>
+        <DataList.Label>Name</DataList.Label>
+        <DataList.Value>{config.content.name}</DataList.Value>
+      </DataList.Item>
+      <DataList.Item>
+        <DataList.Label>Entry</DataList.Label>
+        <DataList.Value>
+          <Flex align="center" gap="2">
+            <Code>{config.content.entry}</Code>
+            <Tooltip content="Open" side="right">
+              <IconButton
+                variant="ghost"
+                size="1"
+                onClick={() =>
+                  invokeOpenInWidgetsDir({
+                    components: [config.content.dir, config.content.entry],
+                  })
+                }
+              >
+                <MdOpenInNew />
+              </IconButton>
+            </Tooltip>
+          </Flex>
+        </DataList.Value>
+      </DataList.Item>
+      <DataList.Item>
+        <DataList.Label>Dependencies</DataList.Label>
+        <DataList.Value>
+          <WidgetDependencies dependencies={config.content.dependencies} />
+        </DataList.Value>
+      </DataList.Item>
+    </DataList.Root>
+  );
+};
 
 export default WidgetContentConfigList;

--- a/src/manager/components/WidgetContentHeading.tsx
+++ b/src/manager/components/WidgetContentHeading.tsx
@@ -1,7 +1,7 @@
 import { Button, Flex, Heading } from "@radix-ui/themes";
-import { ReactNode } from "react";
+import { ReactNode, memo } from "react";
 
-export interface WidgetContentHeadingProps {
+interface WidgetContentHeadingProps {
   /** The component to put in the heading. */
   heading: ReactNode;
   /** The icon for the action button. */
@@ -18,25 +18,24 @@ export interface WidgetContentHeadingProps {
  * This displays the heading aligned left and the action button aligned right. The
  * action button will be composed of the icon then the text.
  */
-export default function WidgetContentHeading({
-  heading,
-  actionIcon,
-  actionText,
-  action,
-}: WidgetContentHeadingProps) {
-  return (
-    <Flex justify="between" align="center">
-      <Heading size="2">{heading}</Heading>
-      <Button
-        size="1"
-        variant="surface"
-        color="gray"
-        highContrast
-        onClick={action}
-      >
-        {actionIcon}
-        {actionText}
-      </Button>
-    </Flex>
-  );
-}
+const WidgetContentHeading = memo(
+  ({ heading, actionIcon, actionText, action }: WidgetContentHeadingProps) => {
+    return (
+      <Flex justify="between" align="center">
+        <Heading size="2">{heading}</Heading>
+        <Button
+          size="1"
+          variant="surface"
+          color="gray"
+          highContrast
+          onClick={action}
+        >
+          {actionIcon}
+          {actionText}
+        </Button>
+      </Flex>
+    );
+  },
+);
+
+export default WidgetContentHeading;

--- a/src/manager/components/WidgetContentHeading.tsx
+++ b/src/manager/components/WidgetContentHeading.tsx
@@ -1,5 +1,5 @@
 import { Button, Flex, Heading } from "@radix-ui/themes";
-import { ReactNode, memo } from "react";
+import { ReactNode } from "react";
 
 interface WidgetContentHeadingProps {
   /** The component to put in the heading. */
@@ -18,24 +18,27 @@ interface WidgetContentHeadingProps {
  * This displays the heading aligned left and the action button aligned right. The
  * action button will be composed of the icon then the text.
  */
-const WidgetContentHeading = memo(
-  ({ heading, actionIcon, actionText, action }: WidgetContentHeadingProps) => {
-    return (
-      <Flex justify="between" align="center">
-        <Heading size="2">{heading}</Heading>
-        <Button
-          size="1"
-          variant="surface"
-          color="gray"
-          highContrast
-          onClick={action}
-        >
-          {actionIcon}
-          {actionText}
-        </Button>
-      </Flex>
-    );
-  },
-);
+const WidgetContentHeading = ({
+  heading,
+  actionIcon,
+  actionText,
+  action,
+}: WidgetContentHeadingProps) => {
+  return (
+    <Flex justify="between" align="center">
+      <Heading size="2">{heading}</Heading>
+      <Button
+        size="1"
+        variant="surface"
+        color="gray"
+        highContrast
+        onClick={action}
+      >
+        {actionIcon}
+        {actionText}
+      </Button>
+    </Flex>
+  );
+};
 
 export default WidgetContentHeading;

--- a/src/manager/components/WidgetContentSettingsList.tsx
+++ b/src/manager/components/WidgetContentSettingsList.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction } from "react";
+import { Dispatch, SetStateAction, memo } from "react";
 import { WidgetSettings } from "../../types/backend";
 import { ManagerWidgetState } from "../../types/frontend";
 import { emitRenderWidgetToCanvas } from "../../events";
@@ -6,7 +6,7 @@ import { DataList, Flex } from "@radix-ui/themes";
 import NumberInput from "../components/NumberInput";
 import { FaTimes } from "react-icons/fa";
 
-export interface WidgetContentSettingListProps {
+interface WidgetContentSettingListProps {
   /** The widget ID. */
   id: string;
   /** The widget-specific setting. */
@@ -24,58 +24,58 @@ export interface WidgetContentSettingListProps {
  * manager will be updated via the setter, and the updated settings will also be sent
  * to the canvas via emitting corresponding events.
  */
-export default function WidgetContentSettingList({
-  id,
-  settings,
-  setManagerWidgetStates,
-}: WidgetContentSettingListProps) {
-  function updateSetting(partialSettings: Partial<WidgetSettings>) {
-    const newSettings = { ...settings, ...partialSettings };
-    setManagerWidgetStates((prev) => ({
-      ...prev,
-      [id]: { ...prev[id], settings: newSettings },
-    }));
-    emitRenderWidgetToCanvas({
-      id,
-      settings: newSettings,
-      bundle: false,
-    }).catch(console.error);
-  }
+const WidgetContentSettingList = memo(
+  ({ id, settings, setManagerWidgetStates }: WidgetContentSettingListProps) => {
+    function updateSetting(partialSettings: Partial<WidgetSettings>) {
+      const newSettings = { ...settings, ...partialSettings };
+      setManagerWidgetStates((prev) => ({
+        ...prev,
+        [id]: { ...prev[id], settings: newSettings },
+      }));
+      emitRenderWidgetToCanvas({
+        id,
+        settings: newSettings,
+        bundle: false,
+      }).catch(console.error);
+    }
 
-  return (
-    <DataList.Root size="2" css={{ gap: "var(--space-2)" }}>
-      <DataList.Item>
-        <DataList.Label>Position (px)</DataList.Label>
-        <DataList.Value>
-          <Flex gap="1" align="center">
+    return (
+      <DataList.Root size="2" css={{ gap: "var(--space-2)" }}>
+        <DataList.Item>
+          <DataList.Label>Position (px)</DataList.Label>
+          <DataList.Value>
+            <Flex gap="1" align="center">
+              <NumberInput
+                value={settings.x}
+                min={0}
+                width="50px"
+                onChange={(value) => updateSetting({ x: value })}
+              />
+              <FaTimes size={10} />
+              <NumberInput
+                value={settings.y}
+                min={0}
+                width="50px"
+                onChange={(value) => updateSetting({ y: value })}
+              />
+            </Flex>
+          </DataList.Value>
+        </DataList.Item>
+        <DataList.Item>
+          <DataList.Label>Opacity (%)</DataList.Label>
+          <DataList.Value>
             <NumberInput
-              value={settings.x}
-              min={0}
+              value={settings.opacity}
+              min={1}
+              max={100}
               width="50px"
-              onChange={(value) => updateSetting({ x: value })}
+              onChange={(value) => updateSetting({ opacity: value })}
             />
-            <FaTimes size={10} />
-            <NumberInput
-              value={settings.y}
-              min={0}
-              width="50px"
-              onChange={(value) => updateSetting({ y: value })}
-            />
-          </Flex>
-        </DataList.Value>
-      </DataList.Item>
-      <DataList.Item>
-        <DataList.Label>Opacity (%)</DataList.Label>
-        <DataList.Value>
-          <NumberInput
-            value={settings.opacity}
-            min={1}
-            max={100}
-            width="50px"
-            onChange={(value) => updateSetting({ opacity: value })}
-          />
-        </DataList.Value>
-      </DataList.Item>
-    </DataList.Root>
-  );
-}
+          </DataList.Value>
+        </DataList.Item>
+      </DataList.Root>
+    );
+  },
+);
+
+export default WidgetContentSettingList;

--- a/src/manager/components/WidgetContentSettingsList.tsx
+++ b/src/manager/components/WidgetContentSettingsList.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, memo } from "react";
+import { Dispatch, SetStateAction } from "react";
 import { WidgetSettings } from "../../types/backend";
 import { ManagerWidgetState } from "../../types/frontend";
 import { emitRenderWidgetToCanvas } from "../../events";
@@ -24,58 +24,60 @@ interface WidgetContentSettingListProps {
  * manager will be updated via the setter, and the updated settings will also be sent
  * to the canvas via emitting corresponding events.
  */
-const WidgetContentSettingList = memo(
-  ({ id, settings, setManagerWidgetStates }: WidgetContentSettingListProps) => {
-    function updateSetting(partialSettings: Partial<WidgetSettings>) {
-      const newSettings = { ...settings, ...partialSettings };
-      setManagerWidgetStates((prev) => ({
-        ...prev,
-        [id]: { ...prev[id], settings: newSettings },
-      }));
-      emitRenderWidgetToCanvas({
-        id,
-        settings: newSettings,
-        bundle: false,
-      }).catch(console.error);
-    }
+const WidgetContentSettingList = ({
+  id,
+  settings,
+  setManagerWidgetStates,
+}: WidgetContentSettingListProps) => {
+  function updateSetting(partialSettings: Partial<WidgetSettings>) {
+    const newSettings = { ...settings, ...partialSettings };
+    setManagerWidgetStates((prev) => ({
+      ...prev,
+      [id]: { ...prev[id], settings: newSettings },
+    }));
+    emitRenderWidgetToCanvas({
+      id,
+      settings: newSettings,
+      bundle: false,
+    }).catch(console.error);
+  }
 
-    return (
-      <DataList.Root size="2" css={{ gap: "var(--space-2)" }}>
-        <DataList.Item>
-          <DataList.Label>Position (px)</DataList.Label>
-          <DataList.Value>
-            <Flex gap="1" align="center">
-              <NumberInput
-                value={settings.x}
-                min={0}
-                width="50px"
-                onChange={(value) => updateSetting({ x: value })}
-              />
-              <FaTimes size={10} />
-              <NumberInput
-                value={settings.y}
-                min={0}
-                width="50px"
-                onChange={(value) => updateSetting({ y: value })}
-              />
-            </Flex>
-          </DataList.Value>
-        </DataList.Item>
-        <DataList.Item>
-          <DataList.Label>Opacity (%)</DataList.Label>
-          <DataList.Value>
+  return (
+    <DataList.Root size="2" css={{ gap: "var(--space-2)" }}>
+      <DataList.Item>
+        <DataList.Label>Position (px)</DataList.Label>
+        <DataList.Value>
+          <Flex gap="1" align="center">
             <NumberInput
-              value={settings.opacity}
-              min={1}
-              max={100}
+              value={settings.x}
+              min={0}
               width="50px"
-              onChange={(value) => updateSetting({ opacity: value })}
+              onChange={(value) => updateSetting({ x: value })}
             />
-          </DataList.Value>
-        </DataList.Item>
-      </DataList.Root>
-    );
-  },
-);
+            <FaTimes size={10} />
+            <NumberInput
+              value={settings.y}
+              min={0}
+              width="50px"
+              onChange={(value) => updateSetting({ y: value })}
+            />
+          </Flex>
+        </DataList.Value>
+      </DataList.Item>
+      <DataList.Item>
+        <DataList.Label>Opacity (%)</DataList.Label>
+        <DataList.Value>
+          <NumberInput
+            value={settings.opacity}
+            min={1}
+            max={100}
+            width="50px"
+            onChange={(value) => updateSetting({ opacity: value })}
+          />
+        </DataList.Value>
+      </DataList.Item>
+    </DataList.Root>
+  );
+};
 
 export default WidgetContentSettingList;

--- a/src/manager/components/WidgetDependencies.tsx
+++ b/src/manager/components/WidgetDependencies.tsx
@@ -7,7 +7,6 @@ import {
   Text,
   Tooltip,
 } from "@radix-ui/themes";
-import { memo } from "react";
 import { LuView } from "react-icons/lu";
 
 interface WidgetDependenciesProps {
@@ -23,7 +22,7 @@ interface WidgetDependenciesProps {
  * names and corresponding version strings. The package names are linked to their URL
  * on [npmjs.com](https://www.npmjs.com/).
  */
-const WidgetDependencies = memo(({ dependencies }: WidgetDependenciesProps) => {
+const WidgetDependencies = ({ dependencies }: WidgetDependenciesProps) => {
   const dependenciesArray = Object.entries(dependencies);
 
   return (
@@ -62,6 +61,6 @@ const WidgetDependencies = memo(({ dependencies }: WidgetDependenciesProps) => {
       )}
     </Flex>
   );
-});
+};
 
 export default WidgetDependencies;

--- a/src/manager/components/WidgetDependencies.tsx
+++ b/src/manager/components/WidgetDependencies.tsx
@@ -7,9 +7,10 @@ import {
   Text,
   Tooltip,
 } from "@radix-ui/themes";
+import { memo } from "react";
 import { LuView } from "react-icons/lu";
 
-export interface WidgetDependenciesProps {
+interface WidgetDependenciesProps {
   /** The dependencies mapping package name to the corresponding version string. */
   dependencies: Record<string, string>;
 }
@@ -22,9 +23,7 @@ export interface WidgetDependenciesProps {
  * names and corresponding version strings. The package names are linked to their URL
  * on [npmjs.com](https://www.npmjs.com/).
  */
-export default function WidgetDependencies({
-  dependencies,
-}: WidgetDependenciesProps) {
+const WidgetDependencies = memo(({ dependencies }: WidgetDependenciesProps) => {
   const dependenciesArray = Object.entries(dependencies);
 
   return (
@@ -63,4 +62,6 @@ export default function WidgetDependencies({
       )}
     </Flex>
   );
-}
+});
+
+export default WidgetDependencies;

--- a/src/manager/components/WidgetTrigger.tsx
+++ b/src/manager/components/WidgetTrigger.tsx
@@ -1,6 +1,5 @@
 import { Box, Flex, Tabs, Text } from "@radix-ui/themes";
 import { WidgetConfig, WidgetConfigType } from "../../types/backend";
-import { memo } from "react";
 
 interface WidgetTriggerProps {
   /** The index of the widget in the collection. */
@@ -16,7 +15,7 @@ interface WidgetTriggerProps {
  * will display the widget name with a green indicator. Otherwise, it will display an
  * error badge with a red indicator.
  */
-const WidgetTrigger = memo(({ index, config }: WidgetTriggerProps) => {
+const WidgetTrigger = ({ index, config }: WidgetTriggerProps) => {
   return (
     <Tabs.Trigger
       value={`tab${index}`}
@@ -51,6 +50,6 @@ const WidgetTrigger = memo(({ index, config }: WidgetTriggerProps) => {
       </Flex>
     </Tabs.Trigger>
   );
-});
+};
 
 export default WidgetTrigger;

--- a/src/manager/components/WidgetTrigger.tsx
+++ b/src/manager/components/WidgetTrigger.tsx
@@ -1,7 +1,8 @@
 import { Box, Flex, Tabs, Text } from "@radix-ui/themes";
 import { WidgetConfig, WidgetConfigType } from "../../types/backend";
+import { memo } from "react";
 
-export interface WidgetTriggerProps {
+interface WidgetTriggerProps {
   /** The index of the widget in the collection. */
   index: number;
   /** The widget configuration. */
@@ -15,7 +16,7 @@ export interface WidgetTriggerProps {
  * will display the widget name with a green indicator. Otherwise, it will display an
  * error badge with a red indicator.
  */
-export default function WidgetTrigger({ index, config }: WidgetTriggerProps) {
+const WidgetTrigger = memo(({ index, config }: WidgetTriggerProps) => {
   return (
     <Tabs.Trigger
       value={`tab${index}`}
@@ -50,4 +51,6 @@ export default function WidgetTrigger({ index, config }: WidgetTriggerProps) {
       </Flex>
     </Tabs.Trigger>
   );
-}
+});
+
+export default WidgetTrigger;

--- a/src/manager/tabs/AboutTab.tsx
+++ b/src/manager/tabs/AboutTab.tsx
@@ -1,7 +1,6 @@
 import { Avatar, DataList, Flex, Heading, Text } from "@radix-ui/themes";
 import ExternalCopyLink from "../components/ExternalCopyLink";
 import Logo from "/deskulpt.svg";
-import { memo } from "react";
 
 /**
  * The about tab in the manager.
@@ -10,7 +9,7 @@ import { memo } from "react";
  * information of the Deskulpt application, including the version, authors, repository,
  * and documentation.
  */
-const AboutTab = memo(() => {
+const AboutTab = () => {
   return (
     <Flex height="100%" pb="9" px="3" justify="center" align="center" gap="3">
       <Flex align="center" justify="center" css={{ flex: 1 }}>
@@ -60,6 +59,6 @@ const AboutTab = memo(() => {
       </Flex>
     </Flex>
   );
-});
+};
 
 export default AboutTab;

--- a/src/manager/tabs/AboutTab.tsx
+++ b/src/manager/tabs/AboutTab.tsx
@@ -1,6 +1,7 @@
 import { Avatar, DataList, Flex, Heading, Text } from "@radix-ui/themes";
 import ExternalCopyLink from "../components/ExternalCopyLink";
 import Logo from "/deskulpt.svg";
+import { memo } from "react";
 
 /**
  * The about tab in the manager.
@@ -9,7 +10,7 @@ import Logo from "/deskulpt.svg";
  * information of the Deskulpt application, including the version, authors, repository,
  * and documentation.
  */
-export default function AboutTab() {
+const AboutTab = memo(() => {
   return (
     <Flex height="100%" pb="9" px="3" justify="center" align="center" gap="3">
       <Flex align="center" justify="center" css={{ flex: 1 }}>
@@ -59,4 +60,6 @@ export default function AboutTab() {
       </Flex>
     </Flex>
   );
-}
+});
+
+export default AboutTab;

--- a/src/manager/tabs/SettingsTab.tsx
+++ b/src/manager/tabs/SettingsTab.tsx
@@ -1,9 +1,9 @@
-import { Dispatch, SetStateAction } from "react";
+import { Dispatch, SetStateAction, memo } from "react";
 import { DataList, Flex } from "@radix-ui/themes";
 import SettingToggleShortcut from "../components/SettingToggleShortcut";
 import Shortcut from "../components/Shortcut";
 
-export interface SettingsTabProps {
+interface SettingsTabProps {
   /** The current toggle shortcut. */
   toggleShortcut: string | null;
   /** Setter for the toggle shortcut state. */
@@ -16,23 +16,24 @@ export interface SettingsTabProps {
  * This tab is rendered as a data list with some margin. It contains the settings and
  * setters for the global settings, which include the toggle shortcut.
  */
-export default function SettingsTab({
-  toggleShortcut,
-  setToggleShortcut,
-}: SettingsTabProps) {
-  const shortcutKeys = toggleShortcut?.split("+") ?? [];
+const SettingsTab = memo(
+  ({ toggleShortcut, setToggleShortcut }: SettingsTabProps) => {
+    const shortcutKeys = toggleShortcut?.split("+") ?? [];
 
-  return (
-    <DataList.Root size="2" mx="3" my="2" css={{ gap: "var(--space-2)" }}>
-      <DataList.Item align="center">
-        <DataList.Label>Toggle shortcut</DataList.Label>
-        <DataList.Value>
-          <Flex align="center" justify="between" width="100%">
-            <Shortcut keys={shortcutKeys} gap="1" />
-            <SettingToggleShortcut setToggleShortcut={setToggleShortcut} />
-          </Flex>
-        </DataList.Value>
-      </DataList.Item>
-    </DataList.Root>
-  );
-}
+    return (
+      <DataList.Root size="2" mx="3" my="2" css={{ gap: "var(--space-2)" }}>
+        <DataList.Item align="center">
+          <DataList.Label>Toggle shortcut</DataList.Label>
+          <DataList.Value>
+            <Flex align="center" justify="between" width="100%">
+              <Shortcut keys={shortcutKeys} gap="1" />
+              <SettingToggleShortcut setToggleShortcut={setToggleShortcut} />
+            </Flex>
+          </DataList.Value>
+        </DataList.Item>
+      </DataList.Root>
+    );
+  },
+);
+
+export default SettingsTab;

--- a/src/manager/tabs/SettingsTab.tsx
+++ b/src/manager/tabs/SettingsTab.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, memo } from "react";
+import { Dispatch, SetStateAction } from "react";
 import { DataList, Flex } from "@radix-ui/themes";
 import SettingToggleShortcut from "../components/SettingToggleShortcut";
 import Shortcut from "../components/Shortcut";
@@ -16,24 +16,25 @@ interface SettingsTabProps {
  * This tab is rendered as a data list with some margin. It contains the settings and
  * setters for the global settings, which include the toggle shortcut.
  */
-const SettingsTab = memo(
-  ({ toggleShortcut, setToggleShortcut }: SettingsTabProps) => {
-    const shortcutKeys = toggleShortcut?.split("+") ?? [];
+const SettingsTab = ({
+  toggleShortcut,
+  setToggleShortcut,
+}: SettingsTabProps) => {
+  const shortcutKeys = toggleShortcut?.split("+") ?? [];
 
-    return (
-      <DataList.Root size="2" mx="3" my="2" css={{ gap: "var(--space-2)" }}>
-        <DataList.Item align="center">
-          <DataList.Label>Toggle shortcut</DataList.Label>
-          <DataList.Value>
-            <Flex align="center" justify="between" width="100%">
-              <Shortcut keys={shortcutKeys} gap="1" />
-              <SettingToggleShortcut setToggleShortcut={setToggleShortcut} />
-            </Flex>
-          </DataList.Value>
-        </DataList.Item>
-      </DataList.Root>
-    );
-  },
-);
+  return (
+    <DataList.Root size="2" mx="3" my="2" css={{ gap: "var(--space-2)" }}>
+      <DataList.Item align="center">
+        <DataList.Label>Toggle shortcut</DataList.Label>
+        <DataList.Value>
+          <Flex align="center" justify="between" width="100%">
+            <Shortcut keys={shortcutKeys} gap="1" />
+            <SettingToggleShortcut setToggleShortcut={setToggleShortcut} />
+          </Flex>
+        </DataList.Value>
+      </DataList.Item>
+    </DataList.Root>
+  );
+};
 
 export default SettingsTab;

--- a/src/manager/tabs/WidgetsTab.tsx
+++ b/src/manager/tabs/WidgetsTab.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction } from "react";
+import { Dispatch, SetStateAction, memo } from "react";
 import { LuFileScan, LuFolderOpen, LuRepeat } from "react-icons/lu";
 import { invokeOpenInWidgetsDir } from "../../commands";
 import { Flex, ScrollArea, Tabs } from "@radix-ui/themes";
@@ -9,7 +9,7 @@ import WidgetContent from "../components/WidgetContent";
 import FloatButton from "../components/FloatButton";
 import { emitRenderWidgetToCanvas } from "../../events";
 
-export interface WidgetsTabProps {
+interface WidgetsTabProps {
   /** The manager widget states. */
   managerWidgetStates: Record<string, ManagerWidgetState>;
   /** Setter for the manager widget states. */
@@ -27,86 +27,92 @@ export interface WidgetsTabProps {
  * bottom right corner. It contains the triggers {@link WidgetTrigger} and the contents
  * {@link WidgetContent} for each widget in the collection.
  */
-export default function WidgetsTab({
-  managerWidgetStates,
-  setManagerWidgetStates,
-  rescanAndRender,
-}: WidgetsTabProps) {
-  const managerWidgetStatesArray = Object.entries(managerWidgetStates);
+const WidgetsTab = memo(
+  ({
+    managerWidgetStates,
+    setManagerWidgetStates,
+    rescanAndRender,
+  }: WidgetsTabProps) => {
+    const managerWidgetStatesArray = Object.entries(managerWidgetStates);
 
-  const rerenderAction = async () => {
-    await Promise.all(
-      managerWidgetStatesArray.map(([id, { settings }]) =>
-        emitRenderWidgetToCanvas({ id, settings, bundle: true }),
-      ),
-    );
-    toast.success(`Re-rendered ${managerWidgetStatesArray.length} widgets.`);
-  };
-
-  const rescanAction = async () => {
-    const count = await rescanAndRender();
-    if (count === 0) {
-      toast.success("Rescanned base directory.");
-    } else {
-      toast.success(
-        `Rescanned base directory and rendered ${count} newly added widgets.`,
+    const rerenderAction = async () => {
+      await Promise.all(
+        managerWidgetStatesArray.map(([id, { settings }]) =>
+          emitRenderWidgetToCanvas({ id, settings, bundle: true }),
+        ),
       );
-    }
-  };
+      toast.success(`Re-rendered ${managerWidgetStatesArray.length} widgets.`);
+    };
 
-  return (
-    <>
-      <Tabs.Root orientation="vertical" defaultValue="tab0" asChild>
-        <Flex gap="3" height="100%">
-          {managerWidgetStatesArray.length > 0 && (
-            <Tabs.List
-              css={{
-                flex: 1,
-                height: "100%",
-                // Move the shadow of the tab list from bottom to right
-                boxShadow: "inset -1px 0 0 0 var(--gray-a5)",
-              }}
-            >
-              <ScrollArea scrollbars="vertical" asChild>
-                <Flex direction="column">
-                  {managerWidgetStatesArray.map(([id, { config }], index) => (
-                    <WidgetTrigger key={id} index={index} config={config} />
-                  ))}
-                </Flex>
-              </ScrollArea>
-            </Tabs.List>
-          )}
-          {managerWidgetStatesArray.map(([id, { config, settings }], index) => (
-            <WidgetContent
-              key={id}
-              index={index}
-              id={id}
-              config={config}
-              settings={settings}
-              setManagerWidgetStates={setManagerWidgetStates}
-            />
-          ))}
-        </Flex>
-      </Tabs.Root>
-      <FloatButton
-        order={3}
-        icon={<LuRepeat />}
-        tooltip="Re-render all widgets"
-        onClick={rerenderAction}
-        disabled={managerWidgetStatesArray.length === 0}
-      />
-      <FloatButton
-        order={2}
-        icon={<LuFileScan />}
-        tooltip="Rescan widgets"
-        onClick={rescanAction}
-      />
-      <FloatButton
-        order={1}
-        icon={<LuFolderOpen />}
-        tooltip="Open base directory"
-        onClick={() => invokeOpenInWidgetsDir({ components: [] })}
-      />
-    </>
-  );
-}
+    const rescanAction = async () => {
+      const count = await rescanAndRender();
+      if (count === 0) {
+        toast.success("Rescanned base directory.");
+      } else {
+        toast.success(
+          `Rescanned base directory and rendered ${count} newly added widgets.`,
+        );
+      }
+    };
+
+    return (
+      <>
+        <Tabs.Root orientation="vertical" defaultValue="tab0" asChild>
+          <Flex gap="3" height="100%">
+            {managerWidgetStatesArray.length > 0 && (
+              <Tabs.List
+                css={{
+                  flex: 1,
+                  height: "100%",
+                  // Move the shadow of the tab list from bottom to right
+                  boxShadow: "inset -1px 0 0 0 var(--gray-a5)",
+                }}
+              >
+                <ScrollArea scrollbars="vertical" asChild>
+                  <Flex direction="column">
+                    {managerWidgetStatesArray.map(([id, { config }], index) => (
+                      <WidgetTrigger key={id} index={index} config={config} />
+                    ))}
+                  </Flex>
+                </ScrollArea>
+              </Tabs.List>
+            )}
+            {managerWidgetStatesArray.map(
+              ([id, { config, settings }], index) => (
+                <WidgetContent
+                  key={id}
+                  index={index}
+                  id={id}
+                  config={config}
+                  settings={settings}
+                  setManagerWidgetStates={setManagerWidgetStates}
+                />
+              ),
+            )}
+          </Flex>
+        </Tabs.Root>
+        <FloatButton
+          order={3}
+          icon={<LuRepeat />}
+          tooltip="Re-render all widgets"
+          onClick={rerenderAction}
+          disabled={managerWidgetStatesArray.length === 0}
+        />
+        <FloatButton
+          order={2}
+          icon={<LuFileScan />}
+          tooltip="Rescan widgets"
+          onClick={rescanAction}
+        />
+        <FloatButton
+          order={1}
+          icon={<LuFolderOpen />}
+          tooltip="Open base directory"
+          onClick={() => invokeOpenInWidgetsDir({ components: [] })}
+        />
+      </>
+    );
+  },
+);
+
+export default WidgetsTab;

--- a/src/manager/tabs/WidgetsTab.tsx
+++ b/src/manager/tabs/WidgetsTab.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction, memo } from "react";
+import { Dispatch, SetStateAction } from "react";
 import { LuFileScan, LuFolderOpen, LuRepeat } from "react-icons/lu";
 import { invokeOpenInWidgetsDir } from "../../commands";
 import { Flex, ScrollArea, Tabs } from "@radix-ui/themes";
@@ -27,92 +27,88 @@ interface WidgetsTabProps {
  * bottom right corner. It contains the triggers {@link WidgetTrigger} and the contents
  * {@link WidgetContent} for each widget in the collection.
  */
-const WidgetsTab = memo(
-  ({
-    managerWidgetStates,
-    setManagerWidgetStates,
-    rescanAndRender,
-  }: WidgetsTabProps) => {
-    const managerWidgetStatesArray = Object.entries(managerWidgetStates);
+const WidgetsTab = ({
+  managerWidgetStates,
+  setManagerWidgetStates,
+  rescanAndRender,
+}: WidgetsTabProps) => {
+  const managerWidgetStatesArray = Object.entries(managerWidgetStates);
 
-    const rerenderAction = async () => {
-      await Promise.all(
-        managerWidgetStatesArray.map(([id, { settings }]) =>
-          emitRenderWidgetToCanvas({ id, settings, bundle: true }),
-        ),
-      );
-      toast.success(`Re-rendered ${managerWidgetStatesArray.length} widgets.`);
-    };
-
-    const rescanAction = async () => {
-      const count = await rescanAndRender();
-      if (count === 0) {
-        toast.success("Rescanned base directory.");
-      } else {
-        toast.success(
-          `Rescanned base directory and rendered ${count} newly added widgets.`,
-        );
-      }
-    };
-
-    return (
-      <>
-        <Tabs.Root orientation="vertical" defaultValue="tab0" asChild>
-          <Flex gap="3" height="100%">
-            {managerWidgetStatesArray.length > 0 && (
-              <Tabs.List
-                css={{
-                  flex: 1,
-                  height: "100%",
-                  // Move the shadow of the tab list from bottom to right
-                  boxShadow: "inset -1px 0 0 0 var(--gray-a5)",
-                }}
-              >
-                <ScrollArea scrollbars="vertical" asChild>
-                  <Flex direction="column">
-                    {managerWidgetStatesArray.map(([id, { config }], index) => (
-                      <WidgetTrigger key={id} index={index} config={config} />
-                    ))}
-                  </Flex>
-                </ScrollArea>
-              </Tabs.List>
-            )}
-            {managerWidgetStatesArray.map(
-              ([id, { config, settings }], index) => (
-                <WidgetContent
-                  key={id}
-                  index={index}
-                  id={id}
-                  config={config}
-                  settings={settings}
-                  setManagerWidgetStates={setManagerWidgetStates}
-                />
-              ),
-            )}
-          </Flex>
-        </Tabs.Root>
-        <FloatButton
-          order={3}
-          icon={<LuRepeat />}
-          tooltip="Re-render all widgets"
-          onClick={rerenderAction}
-          disabled={managerWidgetStatesArray.length === 0}
-        />
-        <FloatButton
-          order={2}
-          icon={<LuFileScan />}
-          tooltip="Rescan widgets"
-          onClick={rescanAction}
-        />
-        <FloatButton
-          order={1}
-          icon={<LuFolderOpen />}
-          tooltip="Open base directory"
-          onClick={() => invokeOpenInWidgetsDir({ components: [] })}
-        />
-      </>
+  const rerenderAction = async () => {
+    await Promise.all(
+      managerWidgetStatesArray.map(([id, { settings }]) =>
+        emitRenderWidgetToCanvas({ id, settings, bundle: true }),
+      ),
     );
-  },
-);
+    toast.success(`Re-rendered ${managerWidgetStatesArray.length} widgets.`);
+  };
+
+  const rescanAction = async () => {
+    const count = await rescanAndRender();
+    if (count === 0) {
+      toast.success("Rescanned base directory.");
+    } else {
+      toast.success(
+        `Rescanned base directory and rendered ${count} newly added widgets.`,
+      );
+    }
+  };
+
+  return (
+    <>
+      <Tabs.Root orientation="vertical" defaultValue="tab0" asChild>
+        <Flex gap="3" height="100%">
+          {managerWidgetStatesArray.length > 0 && (
+            <Tabs.List
+              css={{
+                flex: 1,
+                height: "100%",
+                // Move the shadow of the tab list from bottom to right
+                boxShadow: "inset -1px 0 0 0 var(--gray-a5)",
+              }}
+            >
+              <ScrollArea scrollbars="vertical" asChild>
+                <Flex direction="column">
+                  {managerWidgetStatesArray.map(([id, { config }], index) => (
+                    <WidgetTrigger key={id} index={index} config={config} />
+                  ))}
+                </Flex>
+              </ScrollArea>
+            </Tabs.List>
+          )}
+          {managerWidgetStatesArray.map(([id, { config, settings }], index) => (
+            <WidgetContent
+              key={id}
+              index={index}
+              id={id}
+              config={config}
+              settings={settings}
+              setManagerWidgetStates={setManagerWidgetStates}
+            />
+          ))}
+        </Flex>
+      </Tabs.Root>
+      <FloatButton
+        order={3}
+        icon={<LuRepeat />}
+        tooltip="Re-render all widgets"
+        onClick={rerenderAction}
+        disabled={managerWidgetStatesArray.length === 0}
+      />
+      <FloatButton
+        order={2}
+        icon={<LuFileScan />}
+        tooltip="Rescan widgets"
+        onClick={rescanAction}
+      />
+      <FloatButton
+        order={1}
+        icon={<LuFolderOpen />}
+        tooltip="Open base directory"
+        onClick={() => invokeOpenInWidgetsDir({ components: [] })}
+      />
+    </>
+  );
+};
 
 export default WidgetsTab;


### PR DESCRIPTION
Extracted from #370.

- Props do not need to be exported.
- Components are declared as arrow functions, and then default exported. This will make adding `memo` more elegant.