### PR TITLE
perf: avoid unnecessary rerenders on the canvas

### DIFF
--- a/src/canvas/App.tsx
+++ b/src/canvas/App.tsx
@@ -6,13 +6,13 @@ import { Toaster } from "sonner";
 import { Theme as RadixTheme } from "@radix-ui/themes";
 import useThemeListener from "./hooks/useThemeListener";
 import { useWidgetsStore } from "./hooks/useWidgetsStore";
+import { useShallow } from "zustand/shallow";
 
-/**
- * The main component of the canvas window.
- */
-export default function App() {
+const App = () => {
   const theme = useThemeListener();
-  const widgets = useWidgetsStore((state) => state.widgets);
+  const ids = useWidgetsStore(
+    useShallow((state) => Object.keys(state.widgets)),
+  );
 
   useShowToastListener();
   useRenderWidgetListener();
@@ -37,9 +37,11 @@ export default function App() {
           },
         }}
       />
-      {Object.entries(widgets).map(([id, widget]) => (
-        <WidgetContainer key={id} id={id} widget={widget} />
+      {ids.map((id) => (
+        <WidgetContainer key={id} id={id} />
       ))}
     </RadixTheme>
   );
-}
+};
+
+export default App;

--- a/src/canvas/hooks/useRenderWidgetListener.tsx
+++ b/src/canvas/hooks/useRenderWidgetListener.tsx
@@ -74,13 +74,7 @@ export default function useRenderWidgetListener() {
         // error within `render` so it needs to called in advance, otherwise things will
         // get broken in the state setter, causing the error to be uncaught and also
         // affecting other widget displays
-        updateWidgetRender(
-          id,
-          module.default,
-          moduleBlobUrl,
-          apisBlobUrl,
-          settings,
-        );
+        updateWidgetRender(id, widget, moduleBlobUrl, apisBlobUrl, settings);
       } catch (err) {
         updateWidgetRenderError(id, err, apisBlobUrl, settings);
       }

--- a/src/manager/hooks/useUpdateSettingsListener.ts
+++ b/src/manager/hooks/useUpdateSettingsListener.ts
@@ -22,7 +22,13 @@ export default function useUpdateSettingListener(
 
       setManagerWidgetStates((prev) => {
         if (id in prev) {
-          return { ...prev, [id]: { ...prev[id], settings } };
+          return {
+            ...prev,
+            [id]: {
+              ...prev[id],
+              settings: { ...prev[id].settings, ...settings },
+            },
+          };
         }
         return prev;
       });

--- a/src/types/frontend.ts
+++ b/src/types/frontend.ts
@@ -46,5 +46,5 @@ export interface UpdateSettingsPayload {
   /** The widget ID. */
   id: string;
   /** The widget-specific settings to update. */
-  settings: WidgetSettings;
+  settings: Partial<WidgetSettings>;
 }


### PR DESCRIPTION
Similar to part of #370 but improved.

- `App` rerenders only when rescan, which is currently the possibility to add/remove widgets. This is achieved by `useWidgetsStore(useShallow((state) => Object.keys(state.widgets)))`.
- Each `WidgetContainer` rerenders only when its rendering information or settings change, i.e., `WidgetContainer`s do not affect each other. This is achieved by `useWidgetsStore((state) => state.widgets[id])`.

I'm still uncertain about `React.memo` thing, thus not applying it here, but it is something to consider at some point.