### PR TITLE
chore: read version from `tauri.conf.json` instead of hardcoding

### DIFF
--- a/src/canvas/index.html
+++ b/src/canvas/index.html
@@ -5,6 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/deskulpt.svg" />
     <title>Deskulpt Canvas</title>
+    <script src="http://localhost:8097"></script>
   </head>
 
   <body style="overflow: hidden; margin: 0">

--- a/src/canvas/index.html
+++ b/src/canvas/index.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/deskulpt.svg" />
     <title>Deskulpt Canvas</title>
-    <script src="http://localhost:8097"></script>
   </head>
 
   <body style="overflow: hidden; margin: 0">

--- a/src/manager/tabs/AboutTab.tsx
+++ b/src/manager/tabs/AboutTab.tsx
@@ -33,7 +33,7 @@ const AboutTab = () => {
         <DataList.Root size="2" css={{ gap: "var(--space-1)" }}>
           <DataList.Item>
             <DataList.Label>Version</DataList.Label>
-            <DataList.Value>0.0.1</DataList.Value>
+            <DataList.Value>{__VERSION__}</DataList.Value>
           </DataList.Item>
           <DataList.Item>
             <DataList.Label>Authors</DataList.Label>

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,3 @@
 /// <reference types="vite/client" />
+
+declare const __VERSION__: string;

--- a/src/vite.config.ts
+++ b/src/vite.config.ts
@@ -1,8 +1,12 @@
 import { defineConfig } from "vite";
 import { resolve } from "path";
 import react from "@vitejs/plugin-react";
+import tauriConf from "../crates/deskulpt/tauri.conf.json";
 
 export default defineConfig({
+  define: {
+    __VERSION__: JSON.stringify(tauriConf.version),
+  },
   plugins: [
     react({
       jsxImportSource: "@emotion/react",


### PR DESCRIPTION
Extracted from #370.

This uses Vite's `define` feature: https://vite.dev/config/shared-options.html#define.