### PR TITLE
chore: minor changes to error display

### DIFF
--- a/src/canvas/components/ErrorDisplay.tsx
+++ b/src/canvas/components/ErrorDisplay.tsx
@@ -1,40 +1,26 @@
-import { Badge, Box, Flex, Heading, ScrollArea, Text } from "@radix-ui/themes";
+import { Box, Code, Flex, Heading, ScrollArea } from "@radix-ui/themes";
+import { memo } from "react";
 
 interface ErrorDisplayProps {
-  /** Title of the error display. */
-  title: string;
-  /** The full error message. */
+  id: string;
   error: string;
 }
 
-/**
- * The error display component for user widget errors.
- *
- * It will display an error badge and the error title as a heading, followed by the full
- * error message displayed as pre-wrap monospace text. The component is wrapped in a
- * scroll area is scrollable in both directions.
- */
-const ErrorDisplay = ({ title, error }: ErrorDisplayProps) => {
+const ErrorDisplay = memo(({ id, error }: ErrorDisplayProps) => {
   return (
     <ScrollArea scrollbars="both" asChild>
       <Box p="2">
         <Flex direction="column" gap="2">
-          <Flex align="center" gap="2">
-            <Badge color="red">Error</Badge>
-            <Heading size="2" trim="both" css={{ whiteSpace: "pre" }}>
-              {title}
-            </Heading>
-          </Flex>
-          <Text
-            size="1"
-            css={{ whiteSpace: "pre", fontFamily: "var(--code-font-family)" }}
-          >
+          <Heading size="2" color="red" css={{ whiteSpace: "pre" }}>
+            {id}-{id}
+          </Heading>
+          <Code size="2" variant="ghost" css={{ whiteSpace: "pre" }}>
             {error}
-          </Text>
+          </Code>
         </Flex>
       </Box>
     </ScrollArea>
   );
-};
+});
 
 export default ErrorDisplay;

--- a/src/canvas/components/WidgetContainer.tsx
+++ b/src/canvas/components/WidgetContainer.tsx
@@ -2,7 +2,7 @@ import { RefObject, useCallback, useRef } from "react";
 import Draggable, { DraggableData, DraggableEvent } from "react-draggable";
 import { ErrorBoundary } from "react-error-boundary";
 import ErrorDisplay from "../components/ErrorDisplay";
-import { grabErrorInfo } from "../utils";
+import { stringifyError } from "../utils";
 import { LuGripVertical } from "react-icons/lu";
 import { Box } from "@radix-ui/themes";
 import {
@@ -75,7 +75,7 @@ const WidgetContainer = ({ id }: WidgetContainerProps) => {
         <ErrorBoundary
           resetKeys={[Component]}
           fallbackRender={({ error }) => (
-            <ErrorDisplay title={id} error={grabErrorInfo(error)} />
+            <ErrorDisplay id={id} error={stringifyError(error)} />
           )}
         >
           <Component id={id} />

--- a/src/canvas/hooks/useWidgetsStore.ts
+++ b/src/canvas/hooks/useWidgetsStore.ts
@@ -2,7 +2,7 @@ import { create } from "zustand";
 import { WidgetSettings } from "../../types/backend";
 import { FC, createElement } from "react";
 import ErrorDisplay from "../components/ErrorDisplay";
-import { grabErrorInfo } from "../utils";
+import { stringifyError } from "../utils";
 
 export interface Widget {
   Component: FC<{ id: string }>;
@@ -83,10 +83,7 @@ export function updateWidgetRenderError(
           [id]: {
             ...state.widgets[id],
             Component: () =>
-              createElement(ErrorDisplay, {
-                title: id,
-                error: grabErrorInfo(error),
-              }),
+              createElement(ErrorDisplay, { id, error: stringifyError(error) }),
             width: undefined,
             height: undefined,
             moduleBlobUrl: undefined,
@@ -101,10 +98,7 @@ export function updateWidgetRenderError(
           [id]: {
             ...settings,
             Component: () =>
-              createElement(ErrorDisplay, {
-                title: id,
-                error: grabErrorInfo(error),
-              }),
+              createElement(ErrorDisplay, { id, error: stringifyError(error) }),
             apisBlobUrl,
           },
         },

--- a/src/canvas/utils.ts
+++ b/src/canvas/utils.ts
@@ -1,14 +1,11 @@
 /**
- * Grab as much information as possible from an unknown error.
+ * Stringify an unknown error into a human-readable format.
  *
- * A string error will be returned as is. An `Error` object will return its stack if it
- * exists, otherwise its message. If the error does not fall into any of the above
- * categories, a generic message will be returned.
- *
- * @param err The unknown error, commonly from `catch`.
- * @returns The error information.
+ * A string error will be returned as is. An `Error` object will return its
+ * stack if available, otherwise its message. If the error does not fall into
+ * any of the above categories, a generic message will be returned.
  */
-export function grabErrorInfo(err: unknown) {
+export function stringifyError(err: unknown) {
   if (typeof err === "string") {
     return err;
   }


### PR DESCRIPTION
Extracted from #370.

Simplify the `ErrorDisplay` component. Rename `grabErrorInfo` to `stringifyError`.