### PR TITLE
refactor: better error display and other minor adjustments

### DIFF
--- a/crates/deskulpt-core/src/events.rs
+++ b/crates/deskulpt-core/src/events.rs
@@ -6,7 +6,7 @@ use tauri::{App, AppHandle, Emitter, Runtime};
 
 /// Payload of the `show-toast` event.
 #[derive(Serialize, Clone)]
-#[serde(rename_all = "camelCase")]
+#[serde(tag = "type", content = "content", rename_all = "SCREAMING_SNAKE_CASE")]
 pub enum ShowToastPayload {
     /// Show a [success](https://sonner.emilkowal.ski/toast#success) toast.
     Success(String),

--- a/src/canvas/components/ErrorDisplay.tsx
+++ b/src/canvas/components/ErrorDisplay.tsx
@@ -1,25 +1,39 @@
-import { Box, Code, Flex, Heading, ScrollArea } from "@radix-ui/themes";
+import { Box, Code, Dialog, ScrollArea, Text } from "@radix-ui/themes";
 import { memo } from "react";
 
 interface ErrorDisplayProps {
   id: string;
   error: string;
+  message: string;
 }
 
-const ErrorDisplay = memo(({ id, error }: ErrorDisplayProps) => {
+const ErrorDisplay = memo(({ id, error, message }: ErrorDisplayProps) => {
   return (
-    <ScrollArea scrollbars="both" asChild>
-      <Box p="2">
-        <Flex direction="column" gap="2">
-          <Heading size="2" color="red" css={{ whiteSpace: "pre" }}>
-            {id}-{id}
-          </Heading>
-          <Code size="2" variant="ghost" css={{ whiteSpace: "pre" }}>
-            {error}
-          </Code>
-        </Flex>
-      </Box>
-    </ScrollArea>
+    <Dialog.Root>
+      <Dialog.Trigger>
+        <Box width="100%" height="100%" p="2" css={{ cursor: "pointer" }}>
+          <Text size="2" color="red">
+            An error occurred in widget <Code variant="ghost">{id}</Code>. Click
+            anywhere to check the details.
+          </Text>
+        </Box>
+      </Dialog.Trigger>
+      <Dialog.Content size="2" maxWidth="60vw">
+        <Dialog.Title size="3" color="red" mb="1">
+          Error in widget <Code variant="ghost">{id}</Code>
+        </Dialog.Title>
+        <Dialog.Description size="2" color="red" mb="2">
+          {error}
+        </Dialog.Description>
+        <ScrollArea asChild>
+          <Box pb="3" pr="3" maxHeight="50vh">
+            <Code size="2" variant="ghost" css={{ whiteSpace: "pre" }}>
+              {message}
+            </Code>
+          </Box>
+        </ScrollArea>
+      </Dialog.Content>
+    </Dialog.Root>
   );
 });
 

--- a/src/canvas/components/WidgetContainer.tsx
+++ b/src/canvas/components/WidgetContainer.tsx
@@ -1,7 +1,7 @@
 import { RefObject, memo, useCallback, useRef } from "react";
 import Draggable, { DraggableData, DraggableEvent } from "react-draggable";
 import { ErrorBoundary } from "react-error-boundary";
-import ErrorDisplay from "../components/ErrorDisplay";
+import ErrorDisplay from "./ErrorDisplay";
 import { stringifyError } from "../utils";
 import { LuGripVertical } from "react-icons/lu";
 import { Box } from "@radix-ui/themes";
@@ -75,7 +75,11 @@ const WidgetContainer = memo(({ id }: WidgetContainerProps) => {
         <ErrorBoundary
           resetKeys={[Component]}
           fallbackRender={({ error }) => (
-            <ErrorDisplay id={id} error={stringifyError(error)} />
+            <ErrorDisplay
+              id={id}
+              error="Error in the widget component [React error boundary]"
+              message={stringifyError(error)}
+            />
           )}
         >
           <Component id={id} />

--- a/src/canvas/hooks/useShowToastListener.tsx
+++ b/src/canvas/hooks/useShowToastListener.tsx
@@ -1,14 +1,19 @@
 import { useEffect } from "react";
 import { listenToShowToast } from "../../events";
 import { toast } from "sonner";
+import { ShowToastPayloadType } from "../../types/backend";
 
 export function useShowToastListener() {
   useEffect(() => {
     const unlisten = listenToShowToast((event) => {
-      if ("success" in event.payload) {
-        void toast.success(event.payload.success);
-      } else if ("error" in event.payload) {
-        void toast.error(event.payload.error);
+      const { type, content } = event.payload;
+      switch (type) {
+        case ShowToastPayloadType.SUCCESS:
+          void toast.success(content);
+          break;
+        case ShowToastPayloadType.ERROR:
+          void toast.error(content);
+          break;
       }
     });
 

--- a/src/canvas/utils.ts
+++ b/src/canvas/utils.ts
@@ -1,10 +1,3 @@
-/**
- * Stringify an unknown error into a human-readable format.
- *
- * A string error will be returned as is. An `Error` object will return its
- * stack if available, otherwise its message. If the error does not fall into
- * any of the above categories, a generic message will be returned.
- */
 export function stringifyError(err: unknown) {
   if (typeof err === "string") {
     return err;
@@ -12,5 +5,5 @@ export function stringifyError(err: unknown) {
   if (err instanceof Error) {
     return err.stack ?? err.message;
   }
-  return "Unknown error caught that is neither a string nor an Error";
+  return "Unknown error that is neither a string nor an Error instance";
 }

--- a/src/types/backend.ts
+++ b/src/types/backend.ts
@@ -2,7 +2,14 @@
  * This file contains the types and interfaces that have backend counterparts.
  */
 
-export type ShowToastPayload = { success: string } | { error: string };
+export enum ShowToastPayloadType {
+  SUCCESS = "SUCCESS",
+  ERROR = "ERROR",
+}
+
+export type ShowToastPayload =
+  | { type: ShowToastPayloadType.SUCCESS; content: string }
+  | { type: ShowToastPayloadType.ERROR; content: string };
 
 export enum WidgetConfigType {
   VALID = "VALID",


### PR DESCRIPTION
- Use a `Dialog` modal for the displaying widget error so that it is easier to view.
- Remove JSDoc. Use just normal comments to explain logic. We are already using TypeScript so we do not need JSDoc for type hints, and we are not library to be consumed by people.
- Make `ShowToastPayload` SCREAMING_SNAKE_CASE because it is an enum and it has no good reason to opt-out the rule of SCREAMING_SNAKE_CASE for enum, camelCase for struct.