### PR TITLE
chore: simplify top-level manager structure

### DIFF
--- a/src/manager/App.tsx
+++ b/src/manager/App.tsx
@@ -11,8 +11,15 @@ import Widgets from "./components/Widgets";
 import Settings from "./components/Settings";
 import ThemeToggler from "./components/ThemeToggler";
 
+const tabs = [
+  { value: "widgets", label: "Widgets", content: <Widgets /> },
+  { value: "settings", label: "Settings", content: <Settings /> },
+  { value: "about", label: "About", content: <About /> },
+];
+
 const App = () => {
   const theme = useAppSettingsStore((state) => state.theme);
+  console.log("Rerendered!");
 
   useExitAppListener();
   useInitialRescan();
@@ -42,26 +49,18 @@ const App = () => {
       <Tabs.Root defaultValue="widgets" asChild>
         <Box height="100%" p="2">
           <Tabs.List>
-            <Tabs.Trigger value="widgets">Widgets</Tabs.Trigger>
-            <Tabs.Trigger value="settings">Settings</Tabs.Trigger>
-            <Tabs.Trigger value="about">About</Tabs.Trigger>
+            {tabs.map((tab) => (
+              <Tabs.Trigger key={tab.value} value={tab.value}>
+                {tab.label}
+              </Tabs.Trigger>
+            ))}
           </Tabs.List>
           <Box px="1" py="3" css={{ height: "calc(100% - 40px)" }}>
-            <Tabs.Content value="widgets" asChild>
-              <Box height="100%">
-                <Widgets />
-              </Box>
-            </Tabs.Content>
-            <Tabs.Content value="settings" asChild>
-              <Box height="100%">
-                <Settings />
-              </Box>
-            </Tabs.Content>
-            <Tabs.Content value="about" asChild>
-              <Box height="100%">
-                <About />
-              </Box>
-            </Tabs.Content>
+            {tabs.map((tab) => (
+              <Tabs.Content key={tab.value} value={tab.value} asChild>
+                <Box height="100%">{tab.content}</Box>
+              </Tabs.Content>
+            ))}
           </Box>
         </Box>
       </Tabs.Root>

--- a/src/manager/components/ThemeToggler.tsx
+++ b/src/manager/components/ThemeToggler.tsx
@@ -3,11 +3,11 @@ import { Theme } from "../../types";
 import { MdOutlineDarkMode, MdOutlineLightMode } from "react-icons/md";
 import { toggleTheme } from "../hooks";
 
-interface AppearanceTogglerProps {
+interface ThemeTogglerProps {
   theme: Theme;
 }
 
-const AppearanceToggler = ({ theme }: AppearanceTogglerProps) => {
+const ThemeToggler = ({ theme }: ThemeTogglerProps) => {
   return (
     <Box position="absolute" right="3" top="4">
       <IconButton
@@ -22,4 +22,4 @@ const AppearanceToggler = ({ theme }: AppearanceTogglerProps) => {
   );
 };
 
-export default AppearanceToggler;
+export default ThemeToggler;


### PR DESCRIPTION
We can simplify the top-level manager structure by making a list for the tabs. Since it is not declared inside the `App` components, there will be no rerendering issues.

This also fixes the name of `ThemeToggler` which was inconsistent with its filename due to some previous refactoring.