### PR TITLE
refactor: add show manager shortcut plus refactoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,15 +242,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -957,7 +948,6 @@ name = "deskulpt-core"
 version = "0.0.1"
 dependencies = [
  "anyhow",
- "bincode",
  "deskulpt-plugin",
  "deskulpt-plugin-fs",
  "deskulpt-plugin-sys",
@@ -966,6 +956,7 @@ dependencies = [
  "once_cell",
  "open",
  "oxc",
+ "paste",
  "path-clean",
  "rolldown",
  "rolldown_common",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,12 @@ version    = "0.0.1"
 
 [workspace.dependencies]
 anyhow                         = "1.0.87"
-bincode                        = "1.3.3"
 dunce                          = "1.0.5"
 objc2                          = "0.5.2"
 once_cell                      = "1.20.2"
 open                           = "5.3.1"
 oxc                            = "0.43.0"
+paste                          = "1.0.15"
 path-clean                     = "1.0.1"
 rolldown                       = { git = "https://github.com/rolldown/rolldown.git", tag = "v1.0.0-beta.1" }
 rolldown_common                = { git = "https://github.com/rolldown/rolldown.git", tag = "v1.0.0-beta.1" }

--- a/crates/deskulpt-core/Cargo.toml
+++ b/crates/deskulpt-core/Cargo.toml
@@ -11,11 +11,11 @@ version    = { workspace = true }
 
 [dependencies]
 anyhow                       = { workspace = true }
-bincode                      = { workspace = true }
 dunce                        = { workspace = true }
 once_cell                    = { workspace = true }
 open                         = { workspace = true, features = ["shellexecute-on-windows"] }
 oxc                          = { workspace = true }
+paste                        = { workspace = true }
 path-clean                   = { workspace = true }
 rolldown                     = { workspace = true }
 rolldown_common              = { workspace = true }

--- a/crates/deskulpt-core/src/commands/update_shortcut.rs
+++ b/crates/deskulpt-core/src/commands/update_shortcut.rs
@@ -1,23 +1,9 @@
-use serde::Deserialize;
 use tauri::{command, AppHandle, Runtime};
 
 use super::error::CmdResult;
-use crate::shortcuts::ShortcutsExt;
+use crate::shortcuts::{ShortcutKey, ShortcutsExt};
 
-/// The key of the shortcut to update.
-///
-/// This corresponds to `keyof Shortcuts` in TypeScript.
-#[derive(Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub enum ShortcutKey {
-    ToggleCanvas,
-}
-
-/// Update a shortcut registered in the application.
-///
-/// This command will compare the old and new shortcuts and perform an update
-/// only if it has changed. In that case, the old shortcut (if exists) will be
-/// unregistered and the new shortcut (if exists) will be registered.
+/// Wrapper of [`update_shortcut`](ShortcutsExt::update_shortcut).
 ///
 /// ### Errors
 ///
@@ -31,12 +17,6 @@ pub async fn update_shortcut<R: Runtime>(
     old_shortcut: Option<String>,
     new_shortcut: Option<String>,
 ) -> CmdResult<()> {
-    match key {
-        ShortcutKey::ToggleCanvas => {
-            app_handle
-                .update_toggle_canvas_shortcut(old_shortcut.as_deref(), new_shortcut.as_deref())?;
-        },
-    }
-
+    app_handle.update_shortcut(key, old_shortcut.as_deref(), new_shortcut.as_deref())?;
     Ok(())
 }

--- a/src/manager/components/Settings/index.tsx
+++ b/src/manager/components/Settings/index.tsx
@@ -7,7 +7,7 @@ import SectionTable from "./SectionTable";
 const Settings = memo(() => {
   return (
     <ScrollArea asChild>
-      <Box height="420px" mt="1" pr="3">
+      <Box height="420px" mt="1" pl="1" pr="3">
         <Flex direction="column" gap="4">
           <SectionTable title="Keyboard Shortcuts">
             <Table.Row align="center">
@@ -20,6 +20,13 @@ const Settings = memo(() => {
               <Table.RowHeaderCell>Toggle Canvas</Table.RowHeaderCell>
               <Table.Cell>
                 <Shortcut shortcutKey="toggleCanvas" />
+              </Table.Cell>
+            </Table.Row>
+            <Table.Row align="center">
+              <InfoCell>Show the manager window.</InfoCell>
+              <Table.RowHeaderCell>Show Manager</Table.RowHeaderCell>
+              <Table.Cell>
+                <Shortcut shortcutKey="showManager" />
               </Table.Cell>
             </Table.Row>
           </SectionTable>

--- a/src/types/backend/settings.ts
+++ b/src/types/backend/settings.ts
@@ -5,6 +5,7 @@ export enum Theme {
 
 export interface Shortcuts {
   toggleCanvas: string | null;
+  showManager: string | null;
 }
 
 export interface AppSettings {


### PR DESCRIPTION
Extracted from and refactored upon #370.

This PR does the following:

- Add a `show_manager` shortcut for showing (and focusing) the manager window.
- Refactor `shortcuts.rs`, making a better macro to generate the implementations. Now each time there are only two places to modify in the backend: add an entry for `Shortcuts` in `settings.rs`, then add a `key => listener` pair in `impl_shortcuts!` in `shortcuts.rs`, and two places in the frontend: add the entry for `Shortcuts` in `types/backend/settings.ts`, then make the UI in `manager/components/Settings/index.tsx`.
- Replaced `bincode` with `serde_json` for the settings file. The reason is that, `bincode` seems to do well only when the structure for deserialization is not broken, otherwise `bincode` may directly panic (due to excessive memory allocation, etc). Also our settings won't be so huge that serialization/deserialization performance differ a lot, so `settings.json` would be just fine.