### PR TITLE
chore: avoid unnecessary macro use for shortcuts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -989,7 +989,6 @@ dependencies = [
  "once_cell",
  "open",
  "oxc",
- "paste",
  "path-clean",
  "rolldown",
  "rolldown_common",
@@ -3609,12 +3608,6 @@ dependencies = [
  "smallvec",
  "windows-targets 0.52.6",
 ]
-
-[[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "path-clean"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ objc2                          = "0.6.1"
 once_cell                      = "1.21.1"
 open                           = "5.3.1"
 oxc                            = "0.65.0"
-paste                          = "1.0.15"
 path-clean                     = "1.0.1"
 rolldown                       = { git = "https://github.com/rolldown/rolldown.git", tag = "v1.0.0-beta.8" }
 rolldown_common                = { git = "https://github.com/rolldown/rolldown.git", tag = "v1.0.0-beta.8" }

--- a/crates/deskulpt-core/Cargo.toml
+++ b/crates/deskulpt-core/Cargo.toml
@@ -15,7 +15,6 @@ dunce                        = { workspace = true }
 once_cell                    = { workspace = true }
 open                         = { workspace = true, features = ["shellexecute-on-windows"] }
 oxc                          = { workspace = true }
-paste                        = { workspace = true }
 path-clean                   = { workspace = true }
 rolldown                     = { workspace = true }
 rolldown_common              = { workspace = true }

--- a/crates/deskulpt-core/src/commands/update_shortcut.rs
+++ b/crates/deskulpt-core/src/commands/update_shortcut.rs
@@ -1,7 +1,8 @@
 use tauri::{command, AppHandle, Runtime};
 
 use super::error::CmdResult;
-use crate::shortcuts::{ShortcutKey, ShortcutsExt};
+use crate::settings::ShortcutKey;
+use crate::shortcuts::ShortcutsExt;
 
 /// Wrapper of [`update_shortcut`](ShortcutsExt::update_shortcut).
 ///
@@ -17,6 +18,6 @@ pub async fn update_shortcut<R: Runtime>(
     old_shortcut: Option<String>,
     new_shortcut: Option<String>,
 ) -> CmdResult<()> {
-    app_handle.update_shortcut(key, old_shortcut.as_deref(), new_shortcut.as_deref())?;
+    app_handle.update_shortcut(&key, old_shortcut.as_deref(), new_shortcut.as_deref())?;
     Ok(())
 }

--- a/crates/deskulpt-core/src/settings.rs
+++ b/crates/deskulpt-core/src/settings.rs
@@ -2,6 +2,7 @@
 
 use std::collections::HashMap;
 use std::fs::{create_dir_all, File};
+use std::hash::Hash;
 use std::io::{BufReader, BufWriter};
 use std::path::Path;
 
@@ -20,19 +21,14 @@ enum Theme {
     Dark,
 }
 
-/// Keyboard shortcuts registered in the application.
-///
-/// A keyboard shortcut being `None` means that it is disabled, otherwise it is
-/// a string parsable into [`Shortcut`](tauri_plugin_global_shortcut::Shortcut).
-#[derive(Default, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct Shortcuts {
+/// Keys of keyboard shortcuts registered in the application.
+#[derive(Eq, PartialEq, Hash, Deserialize, Serialize, Debug)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+pub enum ShortcutKey {
     /// For toggling canvas click-through.
-    #[serde(default)]
-    pub toggle_canvas: Option<String>,
+    ToggleCanvas,
     /// For opening the manager window.
-    #[serde(default)]
-    pub open_manager: Option<String>,
+    OpenManager,
 }
 
 /// Application-wide settings.
@@ -44,7 +40,7 @@ struct AppSettings {
     theme: Theme,
     /// The keyboard shortcuts.
     #[serde(default)]
-    shortcuts: Shortcuts,
+    shortcuts: HashMap<ShortcutKey, String>,
 }
 
 /// Per-widget settings.
@@ -65,6 +61,7 @@ struct WidgetSettings {
     opacity: i32,
 }
 
+/// Default value for [`WidgetSettings::opacity`].
 fn default_opacity() -> i32 {
     100
 }
@@ -112,7 +109,7 @@ impl Settings {
     }
 
     /// Get the mutable reference to the keyboard shortcuts.
-    pub fn shortcuts_mut(&mut self) -> &mut Shortcuts {
+    pub fn shortcuts_mut(&mut self) -> &mut HashMap<ShortcutKey, String> {
         &mut self.app.shortcuts
     }
 }

--- a/crates/deskulpt-core/src/shortcuts.rs
+++ b/crates/deskulpt-core/src/shortcuts.rs
@@ -1,114 +1,105 @@
 //! Keyboard shortcut management.
 
 use anyhow::{bail, Result};
-use paste::paste;
-use serde::Deserialize;
 use tauri::{App, AppHandle, Manager, Runtime};
-use tauri_plugin_global_shortcut::{GlobalShortcutExt, ShortcutState};
+use tauri_plugin_global_shortcut::{GlobalShortcut, GlobalShortcutExt, ShortcutState};
 
-use crate::settings::Settings;
+use crate::settings::{Settings, ShortcutKey};
 use crate::states::StatesExtCanvasClickThrough;
 use crate::WindowExt;
 
-/// Implement [`ShortcutKey`] and [`ShortcutsExt`] for the given shortcuts.
-///
-/// This macro takes a list of `key => listener` pairs, where `key` corresponds
-/// to the keys of [`Shortcuts`](crate::settings::Shortcuts) and `listener` is
-/// the corresponding shortcut handler callback.
-macro_rules! impl_shortcuts {
-    ($($key: ident => $listener: expr),* $(,)?) => {
-        paste! {
-            /// Keyboard shortcuts registered in the application.
-            #[derive(Deserialize)]
-            #[serde(rename_all = "camelCase")]
-            pub enum ShortcutKey {
-                $(
-                    [<$key:upper:camel>], // lower_snake_case => UpperCamelCase
-                )*
-            }
-        }
-
-        /// Extension trait for keyboard shortcuts.
-        pub trait ShortcutsExt<R: Runtime>: Manager<R> + GlobalShortcutExt<R> {
-            /// Initialize keyboard shortcuts according to the initial settings.
-            ///
-            /// If any shortcut fails to be registered, the initial settings will be
-            /// modified to remove that shortcut. This is to prevent the application
-            /// from panicking only due to non-critical failures, and also sync this
-            /// information to the frontend.
-            fn init_shortcuts(&self, settings: &mut Settings) {
-                let shortcuts = settings.shortcuts_mut();
-                paste! {
-                    $(
-                        if let Err(e) = self.update_shortcut(
-                            ShortcutKey::[<$key:upper:camel>],
-                            None,
-                            shortcuts.$key.as_deref(),
-                        ) {
-                            eprintln!("{}: {}", stringify!($key), e);
-                            shortcuts.$key = None;
-                        }
-                    )*
-                }
-            }
-
-            /// Update a shortcut registered in the application.
-            ///
-            /// This function will compare the old and new shortcuts and perform an update
-            /// only if it has changed. In that case, the old shortcut (if exists) will be
-            /// unregistered and the new shortcut (if exists) will be registered.
-            fn update_shortcut(
-                &self,
-                key: ShortcutKey,
-                old_shortcut: Option<&str>,
-                new_shortcut: Option<&str>,
-            ) -> Result<()> {
-                if old_shortcut == new_shortcut {
-                    return Ok(());
-                }
-                let manager = self.global_shortcut();
-
-                if let Some(shortcut) = old_shortcut {
-                    if !manager.is_registered(shortcut) {
-                        bail!("Cannot unregister '{shortcut}': not registered yet");
-                    }
-                    manager.unregister(shortcut)?;
-                }
-
-                if let Some(shortcut) = new_shortcut {
-                    if manager.is_registered(shortcut) {
-                        bail!("Cannot register '{shortcut}': already registered");
-                    }
-                    paste! {
-                        match key {
-                            $(
-                                ShortcutKey::[<$key:upper:camel>] => {
-                                    manager.on_shortcut(shortcut, $listener)?;
-                                },
-                            )*
-                        }
-                    }
-                }
-
-                Ok(())
-            }
-        }
-    };
+/// Trait that defines the handling of a keyboard shortcut.
+trait ShortcutHandler<R: Runtime> {
+    /// Register the keyboard shortcut.
+    fn register(manager: &GlobalShortcut<R>, shortcut: &str) -> Result<()>;
 }
 
-impl_shortcuts! {
-    toggle_canvas => |app_handle, _, event| {
-        if event.state == ShortcutState::Pressed {
-            if let Err(e) = app_handle.toggle_canvas_click_through() {
-                eprintln!("Failed to toggle canvas click-through: {e}");
+/// Handler for [`ShortcutKey::ToggleCanvas`].
+struct ToggleCanvasHandler;
+
+impl<R: Runtime> ShortcutHandler<R> for ToggleCanvasHandler {
+    fn register(manager: &GlobalShortcut<R>, shortcut: &str) -> Result<()> {
+        manager.on_shortcut(shortcut, |app_handle, _, event| {
+            if event.state == ShortcutState::Pressed {
+                if let Err(e) = app_handle.toggle_canvas_click_through() {
+                    eprintln!("Failed to toggle canvas click-through: {e}");
+                }
+            }
+        })?;
+        Ok(())
+    }
+}
+
+/// Handler for [`ShortcutKey::OpenManager`].
+struct OpenManagerHandler;
+
+impl<R: Runtime> ShortcutHandler<R> for OpenManagerHandler {
+    fn register(manager: &GlobalShortcut<R>, shortcut: &str) -> Result<()> {
+        manager.on_shortcut(shortcut, |app_handle, _, _| {
+            if let Err(e) = app_handle.open_manager() {
+                eprintln!("Failed to open the manager window: {e}");
+            }
+        })?;
+        Ok(())
+    }
+}
+
+/// Extension trait for keyboard shortcuts.
+pub trait ShortcutsExt<R: Runtime>: Manager<R> + GlobalShortcutExt<R> {
+    /// Initialize keyboard shortcuts according to the initial settings.
+    ///
+    /// If any shortcut fails to be registered, the initial settings will be
+    /// modified to remove that shortcut. This is to prevent the application
+    /// from panicking only due to non-critical failures, and also sync this
+    /// information to the frontend on startup.
+    fn init_shortcuts(&self, settings: &mut Settings) {
+        settings.shortcuts_mut().retain(|key, shortcut| {
+            match self.update_shortcut(key, None, Some(shortcut)) {
+                Ok(_) => true,
+                Err(e) => {
+                    eprintln!("{:?}: {}", key, e);
+                    false
+                },
+            }
+        });
+    }
+
+    /// Update a shortcut registered in the application.
+    ///
+    /// This function will compare the old and new shortcuts and perform an
+    /// update only if it has changed. In that case, the old shortcut (if
+    /// exists) will be unregistered and the new shortcut (if exists) will be
+    /// registered.
+    fn update_shortcut(
+        &self,
+        key: &ShortcutKey,
+        old_shortcut: Option<&str>,
+        new_shortcut: Option<&str>,
+    ) -> Result<()> {
+        if old_shortcut == new_shortcut {
+            return Ok(());
+        }
+        let manager = self.global_shortcut();
+
+        if let Some(shortcut) = old_shortcut {
+            if !manager.is_registered(shortcut) {
+                bail!("Cannot unregister '{shortcut}': not registered yet");
+            }
+            manager.unregister(shortcut)?;
+        }
+
+        if let Some(shortcut) = new_shortcut {
+            if manager.is_registered(shortcut) {
+                bail!("Cannot register '{shortcut}': already registered");
+            }
+            match key {
+                ShortcutKey::ToggleCanvas => ToggleCanvasHandler::register(manager, shortcut)?,
+                ShortcutKey::OpenManager => OpenManagerHandler::register(manager, shortcut)?,
             }
         }
-    },
-    open_manager => |app_handle, _, _| {
-        if let Err(e) = app_handle.open_manager() {
-            eprintln!("Failed to open the manager window: {e}");
-        }
-    },
+
+        Ok(())
+    }
 }
 
 impl<R: Runtime> ShortcutsExt<R> for App<R> {}

--- a/src/core/commands.ts
+++ b/src/core/commands.ts
@@ -1,5 +1,5 @@
 import { invoke } from "@tauri-apps/api/core";
-import { Settings, Shortcuts, WidgetConfig } from "../types";
+import { Settings, ShortcutKey, WidgetConfig } from "../types";
 import { RenderWidgetsPayload } from "./events";
 
 export const bundleWidget = (payload: {
@@ -23,7 +23,7 @@ export const rescanWidgets = () =>
 export const setRenderReady = () => invoke<void>("set_render_ready");
 
 export const updateShortcut = (payload: {
-  key: keyof Shortcuts;
-  oldShortcut: string | null;
-  newShortcut: string | null;
+  key: ShortcutKey;
+  oldShortcut?: string;
+  newShortcut?: string;
 }) => invoke<void>("update_shortcut", payload);

--- a/src/manager/components/Settings/Shortcut.tsx
+++ b/src/manager/components/Settings/Shortcut.tsx
@@ -16,7 +16,7 @@ import {
 } from "react";
 import { FaEdit } from "react-icons/fa";
 import { MdClear } from "react-icons/md";
-import { Shortcuts } from "../../../types";
+import { ShortcutKey } from "../../../types";
 import { updateShortcut, useAppSettingsStore } from "../../hooks";
 import { toast } from "sonner";
 import { INVALID_KEYCODES, KEYCODES, MODIFIERS } from "./keyboard";
@@ -36,7 +36,7 @@ const styles = {
 };
 
 interface Props {
-  shortcutKey: keyof Shortcuts;
+  shortcutKey: ShortcutKey;
 }
 
 const ShortcutAction = ({ shortcutKey }: Props) => {
@@ -126,7 +126,7 @@ const ShortcutAction = ({ shortcutKey }: Props) => {
   }, []);
 
   const confirmAction = useCallback(() => {
-    updateShortcut(shortcutKey, shortcut, value === "" ? null : value)
+    updateShortcut(shortcutKey, shortcut, value === "" ? undefined : value)
       .then(() => {
         setPlaceholder(INITIAL_PLACEHOLDER);
         setIsValid(true);

--- a/src/manager/components/Settings/index.tsx
+++ b/src/manager/components/Settings/index.tsx
@@ -3,6 +3,7 @@ import { memo } from "react";
 import Shortcut from "./Shortcut";
 import InfoCell from "./InfoCell";
 import SectionTable from "./SectionTable";
+import { ShortcutKey } from "../../../types";
 
 const Settings = memo(() => {
   return (
@@ -20,14 +21,14 @@ const Settings = memo(() => {
               </InfoCell>
               <Table.RowHeaderCell>Toggle Canvas</Table.RowHeaderCell>
               <Table.Cell>
-                <Shortcut shortcutKey="toggleCanvas" />
+                <Shortcut shortcutKey={ShortcutKey.TOGGLE_CANVAS} />
               </Table.Cell>
             </Table.Row>
             <Table.Row align="center">
               <InfoCell>Open this manager window.</InfoCell>
               <Table.RowHeaderCell>Open Manager</Table.RowHeaderCell>
               <Table.Cell>
-                <Shortcut shortcutKey="openManager" />
+                <Shortcut shortcutKey={ShortcutKey.OPEN_MANAGER} />
               </Table.Cell>
             </Table.Row>
           </SectionTable>

--- a/src/manager/hooks/useAppSettingsStore.ts
+++ b/src/manager/hooks/useAppSettingsStore.ts
@@ -1,5 +1,5 @@
 import { create } from "zustand";
-import { Shortcuts, Theme } from "../../types";
+import { ShortcutKey, Theme } from "../../types";
 import { commands, events } from "../../core";
 
 export const useAppSettingsStore = create(() => ({
@@ -15,9 +15,9 @@ export async function toggleTheme() {
 }
 
 export async function updateShortcut(
-  key: keyof Shortcuts,
-  oldShortcut: string | null,
-  newShortcut: string | null,
+  key: ShortcutKey,
+  oldShortcut?: string,
+  newShortcut?: string,
 ) {
   await commands.updateShortcut({ key, oldShortcut, newShortcut });
   useAppSettingsStore.setState((state) => ({

--- a/src/types/backend/settings.ts
+++ b/src/types/backend/settings.ts
@@ -3,14 +3,14 @@ export enum Theme {
   DARK = "dark",
 }
 
-export interface Shortcuts {
-  toggleCanvas: string | null;
-  openManager: string | null;
+export enum ShortcutKey {
+  TOGGLE_CANVAS = "TOGGLE_CANVAS",
+  OPEN_MANAGER = "OPEN_MANAGER",
 }
 
 export interface AppSettings {
   theme: Theme;
-  shortcuts: Shortcuts;
+  shortcuts: Partial<Record<ShortcutKey, string>>;
 }
 
 export interface WidgetSettings {


### PR DESCRIPTION
We should try to avoid unnecessary macro use. Intellisense cannot give good hints and formatter is not happy with macros. In the `shortcuts.rs` case, we simply want a different handler for each shortcut. This can be easily done by making a helper trait `ShortcutHandler` and implementing it for each kind of shortcut. Another difficulty was that perviously we had `shortcuts.xxx`. Things will become simpler if we convert it into a hashmap with enum key.