### PR TITLE
fix: window initialization scripts invalid properties

### DIFF
--- a/crates/deskulpt-core/src/window/canvas.js
+++ b/crates/deskulpt-core/src/window/canvas.js
@@ -11,6 +11,6 @@ Object.defineProperty(window, "__DESKULPT_CANVAS_INTERNALS__", {
 const props = window.__DESKULPT_CANVAS_INTERNALS__;
 Object.freeze(props);
 Object.freeze(props.initialSettings);
-Object.values(props.initialSettings.widgetSettingsMap).forEach((value) => {
+Object.values(props.initialSettings.widgets).forEach((value) => {
   Object.freeze(value);
 });

--- a/crates/deskulpt-core/src/window/manager.js
+++ b/crates/deskulpt-core/src/window/manager.js
@@ -7,9 +7,9 @@ Object.defineProperty(window, "__DESKULPT_MANAGER_INTERNALS__", {
   enumerable: false,
 });
 
-const props = window.__DESKULPT_CANVAS_INTERNALS__;
+const props = window.__DESKULPT_MANAGER_INTERNALS__;
 Object.freeze(props);
 Object.freeze(props.initialSettings);
-Object.values(props.initialSettings.widgetSettingsMap).forEach((value) => {
+Object.values(props.initialSettings.widgets).forEach((value) => {
   Object.freeze(value);
 });


### PR DESCRIPTION
Since these two scripts do not have type checks and these errors are just about freezing the properties, they never really had visible effects and we have long overlooked them.