### PR TITLE
refactor: widget config construct and serialization

### DIFF
--- a/crates/deskulpt-core/src/commands/bundle_widget.rs
+++ b/crates/deskulpt-core/src/commands/bundle_widget.rs
@@ -30,10 +30,12 @@ pub async fn bundle_widget<R: Runtime>(
             .get(&id)
             .ok_or_else(|| cmderr!("Widget (id={}) does not exist", id))?
         {
-            WidgetConfig::Valid { dir, entry, .. } => {
+            WidgetConfig::Valid {
+                dir, deskulpt_conf, ..
+            } => {
                 let builder = WidgetBundlerBuilder::new(
                     widgets_dir.join(dir),
-                    entry.clone(),
+                    deskulpt_conf.entry.clone(),
                     base_url,
                     apis_blob_url,
                 );

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -21,6 +21,25 @@ theme: Theme;
 shortcuts: Shortcuts }
 
 /**
+ * Deserialized `deskulpt.conf.json`.
+ */
+export type DeskulptConf = { 
+/**
+ * The name of the widget.
+ * 
+ * This is purely used for display purposes. It does not need to be related
+ * to the widget directory name, and it does not need to be unique.
+ */
+name: string; 
+/**
+ * The entry point of the widget.
+ * 
+ * This is the path to the file that exports the widget component. The path
+ * should be relative to the widget directory.
+ */
+entry: string }
+
+/**
  * Deskulpt window enum.
  */
 export type DeskulptWindow = 
@@ -42,6 +61,11 @@ export type DeskulptWindow =
 export type ExitAppEvent = null
 
 export type JsonValue = null | boolean | number | string | JsonValue[] | { [key in string]: JsonValue }
+
+/**
+ * Deserialized `package.json`.
+ */
+export type PackageJson = { dependencies?: { [key in string]: string } }
 
 /**
  * Event for removing widgets.
@@ -183,35 +207,11 @@ export type WidgetConfig =
 /**
  * Valid widget configuration.
  */
-{ type: "VALID"; content: { 
-/**
- * The directory name of the widget.
- */
-dir: string; 
-/**
- * Display name of the widget.
- */
-name: string; 
-/**
- * Entry file of the widget source code.
- */
-entry: string; 
-/**
- * External dependencies of the widget as in `package.json`.
- */
-dependencies: { [key in string]: string } } } | 
+{ type: "VALID"; dir: string; deskulptConf: DeskulptConf; packageJson: PackageJson | null } | 
 /**
  * Invalid widget configuration.
  */
-{ type: "INVALID"; content: { 
-/**
- * The directory name of the widget.
- */
-dir: string; 
-/**
- * Error message.
- */
-error: string } }
+{ type: "INVALID"; dir: string; error: string }
 
 /**
  * Per-widget settings.

--- a/src/manager/components/Widgets/Config.tsx
+++ b/src/manager/components/Widgets/Config.tsx
@@ -28,16 +28,18 @@ const Config = memo(({ id }: ConfigProps) => {
             <Table.Body>
               <Table.Row align="center">
                 <Table.RowHeaderCell>Name</Table.RowHeaderCell>
-                <Table.Cell>{config.content.name}</Table.Cell>
+                <Table.Cell>{config.deskulptConf.name}</Table.Cell>
               </Table.Row>
               <Table.Row align="center">
                 <Table.RowHeaderCell>Entry</Table.RowHeaderCell>
-                <Table.Cell>{config.content.entry}</Table.Cell>
+                <Table.Cell>{config.deskulptConf.entry}</Table.Cell>
               </Table.Row>
               <Table.Row align="center">
                 <Table.RowHeaderCell>Dependencies</Table.RowHeaderCell>
                 <Table.Cell>
-                  <Dependencies dependencies={config.content.dependencies} />
+                  <Dependencies
+                    dependencies={config.packageJson?.dependencies}
+                  />
                 </Table.Cell>
               </Table.Row>
             </Table.Body>
@@ -46,7 +48,7 @@ const Config = memo(({ id }: ConfigProps) => {
           <Box pl="2" m="0" asChild>
             <pre>
               <Code size="2" variant="ghost">
-                {config.content.error}
+                {config.error}
               </Code>
             </pre>
           </Box>

--- a/src/manager/components/Widgets/Dependencies.tsx
+++ b/src/manager/components/Widgets/Dependencies.tsx
@@ -17,7 +17,7 @@ interface DependenciesProps {
 
 const Dependencies = memo(({ dependencies }: DependenciesProps) => {
   const dependenciesArray =
-    dependencies !== undefined ? Object.entries(dependencies) : [];
+    dependencies === undefined ? [] : Object.entries(dependencies);
 
   return dependenciesArray.length > 0 ? (
     <Popover.Root>

--- a/src/manager/components/Widgets/Dependencies.tsx
+++ b/src/manager/components/Widgets/Dependencies.tsx
@@ -12,11 +12,12 @@ const styles = {
 };
 
 interface DependenciesProps {
-  dependencies: { [key in string]?: string };
+  dependencies?: Record<string, string>;
 }
 
 const Dependencies = memo(({ dependencies }: DependenciesProps) => {
-  const dependenciesArray = Object.entries(dependencies);
+  const dependenciesArray =
+    dependencies !== undefined ? Object.entries(dependencies) : [];
 
   return dependenciesArray.length > 0 ? (
     <Popover.Root>

--- a/src/manager/components/Widgets/Trigger.tsx
+++ b/src/manager/components/Widgets/Trigger.tsx
@@ -43,7 +43,7 @@ const Trigger = memo(({ id, value }: TriggerProps) => {
             config.type === "INVALID" && styles.indicatorInvalid,
           ]}
         />
-        <Text>{config.content.dir}</Text>
+        <Text>{config.dir}</Text>
       </Flex>
     </Tabs.Trigger>
   );

--- a/src/manager/hooks/useWidgetsStore.ts
+++ b/src/manager/hooks/useWidgetsStore.ts
@@ -54,7 +54,7 @@ export async function rescan(initial: boolean = false) {
   useWidgetsStore.setState({
     widgets: Object.fromEntries(
       widgetsArray.sort(([, a], [, b]) =>
-        a.config.content.dir.localeCompare(b.config.content.dir),
+        a.config.dir.localeCompare(b.config.dir),
       ),
     ),
   });


### PR DESCRIPTION
- Directly nest `deskulpt_conf and `package_json` in `WidgetConfig`. This can help reduce repetitions as we add more fields.
- The reasons for not adding `#[serde(flatten)]`: specta does not respect this attribute when used in enums; `Option<T>` cannot be marked with flatten.
- Remove `#[serde(content = "content")]` to reduce nesting level.