### PR TITLE
feat: generate settings schema

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -24,7 +24,9 @@ jobs:
           platform: ubuntu-latest
 
       - name: Build docs
-        run: pnpm docs:build
+        run: |
+          pnpm build:schema
+          pnpm docs:build
 
       - name: Build rustdoc
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ crates/deskulpt/gen/schemas/
 # Docs
 docs/.vitepress/dist/
 docs/.vitepress/cache/
+docs/src/public/settings-schema.json

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1040,6 +1040,7 @@ version = "0.0.1"
 dependencies = [
  "deskulpt-core",
  "deskulpt-specta",
+ "schemars 1.0.4",
  "serde_json",
  "specta",
  "tauri",
@@ -1068,6 +1069,7 @@ dependencies = [
  "path-clean",
  "rolldown",
  "rolldown_common",
+ "schemars 1.0.4",
  "serde",
  "serde_json",
  "serialize-to-javascript",
@@ -4448,6 +4450,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.95",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4920,7 +4942,7 @@ checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
 dependencies = [
  "dyn-clone",
  "indexmap 1.9.3",
- "schemars_derive",
+ "schemars_derive 0.8.21",
  "serde",
  "serde_json",
  "url",
@@ -4928,10 +4950,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive 1.0.4",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "schemars_derive"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.95",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33d020396d1d138dc19f1165df7545479dcd58d93810dc5d646a16e55abefa80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5610,7 +5657,7 @@ dependencies = [
  "heck 0.5.0",
  "json-patch",
  "quote",
- "schemars",
+ "schemars 0.8.21",
  "semver",
  "serde",
  "serde_json",
@@ -5671,7 +5718,7 @@ dependencies = [
  "anyhow",
  "glob",
  "plist",
- "schemars",
+ "schemars 0.8.21",
  "serde",
  "serde_json",
  "tauri-utils",
@@ -5720,7 +5767,7 @@ dependencies = [
  "objc2-app-kit 0.3.1",
  "objc2-foundation 0.3.1",
  "open",
- "schemars",
+ "schemars 0.8.21",
  "serde",
  "serde_json",
  "tauri",
@@ -5831,7 +5878,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "schemars",
+ "schemars 0.8.21",
  "semver",
  "serde",
  "serde-untagged",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ quote                          = "1.0.38"
 regex                          = "1.11.2"
 rolldown                       = { git = "https://github.com/rolldown/rolldown.git", tag = "v1.0.0-beta.27" }
 rolldown_common                = { git = "https://github.com/rolldown/rolldown.git", tag = "v1.0.0-beta.27" }
+schemars                       = "1.0.4"
 serde                          = "1.0.210"
 serde_json                     = "1.0.128"
 serialize-to-javascript        = "0.1.1"

--- a/crates/deskulpt-core/Cargo.toml
+++ b/crates/deskulpt-core/Cargo.toml
@@ -20,6 +20,7 @@ paste                        = { workspace = true }
 path-clean                   = { workspace = true }
 rolldown                     = { workspace = true }
 rolldown_common              = { workspace = true }
+schemars                     = { workspace = true }
 serde                        = { workspace = true, features = ["derive"] }
 serde_json                   = { workspace = true }
 serialize-to-javascript      = { workspace = true }

--- a/crates/deskulpt/Cargo.toml
+++ b/crates/deskulpt/Cargo.toml
@@ -21,6 +21,7 @@ tauri-specta                   = { workspace = true }
 
 [dev-dependencies]
 deskulpt-specta = { workspace = true }
+schemars        = { workspace = true }
 
 [build-dependencies]
 tauri-build = { workspace = true, features = ["codegen"] }

--- a/crates/deskulpt/src/main.rs
+++ b/crates/deskulpt/src/main.rs
@@ -10,9 +10,28 @@ mod export_bindings {
 
     #[test]
     #[ignore]
-    fn main() {
+    fn export_all() {
         deskulpt::get_bindings_builder()
             .export(TypeScript::default(), "../../src/bindings.ts")
             .expect("Failed to export TypeScript bindings");
+    }
+}
+
+#[cfg(test)]
+mod export_schema {
+    use std::fs::File;
+    use std::io::BufWriter;
+
+    use deskulpt_core::settings::Settings;
+    use schemars::schema_for;
+
+    #[test]
+    #[ignore]
+    fn export_settings() {
+        let schema = schema_for!(Settings);
+        let file = File::create("../../docs/src/public/settings-schema.json")
+            .expect("Failed to create file");
+        let writer = BufWriter::new(file);
+        serde_json::to_writer_pretty(writer, &schema).expect("Failed to write schema");
     }
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "docs:preview": "pnpm -C docs preview",
     "docs:rs": "cargo doc --workspace --no-deps",
     "build:packages": "pnpm run --filter \"@deskulpt-test/*\" build",
-    "build:bindings": "cargo test --bin deskulpt export_bindings -- --ignored"
+    "build:bindings": "cargo test --bin deskulpt export_bindings -- --ignored",
+    "build:schema": "cargo test --bin deskulpt export_schema -- --ignored"
   },
   "devDependencies": {
     "@tauri-apps/cli": "^2.8.2",

--- a/src/bindings.ts
+++ b/src/bindings.ts
@@ -110,7 +110,7 @@ settings?: WidgetSettings;
 code?: string }
 
 /**
- * Full settings of the application.
+ * Full settings of the Deskulpt application.
  */
 export type Settings = { 
 /**


### PR DESCRIPTION
Following #500 which pretty prints the settings JSON, this PR is adding `$schema` to help users when they manually edit this file. Though in most cases people should still use app UI for settings this is still an important part of UX as long as we support manual edits.

Generation is done with [schemars](https://docs.rs/schemars/latest/schemars/) and dev-only with a test for generation (same pattern as generating bindings). Schema generation is done in the docs CI and served by vitepress under `/settings-schema.json`.

The command for generating the schema is:

```shell
pnpm build:schema
```

You can find the generated file at `docs/src/public/settings-schema.json`, or you can run `pnpm docs:dev` and go to http://localhost:5173/settings-schema.json. After this PR is merged and the new docs is deployed, the schema file should be available at https://csci-shu-410-se-project.github.io/settings-schema.json, which is the URL we use for `$schema`.