### PR TITLE
fix: manager ui when there are no widgets

### DIFF
--- a/src/manager/components/Widgets/index.tsx
+++ b/src/manager/components/Widgets/index.tsx
@@ -1,4 +1,4 @@
-import { Flex, ScrollArea, Separator, Tabs } from "@radix-ui/themes";
+import { Flex, ScrollArea, Separator, Tabs, Text } from "@radix-ui/themes";
 import { useWidgetsStore } from "../../hooks";
 import { memo } from "react";
 import { useShallow } from "zustand/shallow";
@@ -35,21 +35,33 @@ const WidgetsTab = memo(() => {
             <GlobalActions length={ids.length} />
           </Flex>
         </Tabs.List>
-        {ids.map((id, index) => (
-          <Tabs.Content
-            key={id}
-            value={`tab${index}`}
+        {ids.length === 0 ? (
+          <Flex
+            direction="column"
+            align="center"
+            justify="center"
+            width="75%"
             css={styles.tabContent}
-            asChild
           >
-            <Flex height="100%" direction="column" pl="2" gap="2" width="75%">
-              <Header id={id} />
-              <Config id={id} />
-              <Separator size="4" />
-              <Settings id={id} />
-            </Flex>
-          </Tabs.Content>
-        ))}
+            <Text size="2">No widgets available</Text>
+          </Flex>
+        ) : (
+          ids.map((id, index) => (
+            <Tabs.Content
+              key={id}
+              value={`tab${index}`}
+              css={styles.tabContent}
+              asChild
+            >
+              <Flex height="100%" direction="column" pl="2" gap="2" width="75%">
+                <Header id={id} />
+                <Config id={id} />
+                <Separator size="4" />
+                <Settings id={id} />
+              </Flex>
+            </Tabs.Content>
+          ))
+        )}
       </Flex>
     </Tabs.Root>
   );


### PR DESCRIPTION
Previously the right half is completely empty and there is no vertical bar there, which looks really strange. Now it looks like the following:

<img width="1597" height="1044" alt="image" src="https://github.com/user-attachments/assets/2c9333ec-cf61-415f-8c22-c7a1fa8b0a9d" />
