### PR TITLE
chore: try to allow patch updates in dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,9 +7,6 @@ updates:
       interval: weekly
     labels:
       - dependencies
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
     groups:
       rust:
         patterns:
@@ -22,9 +19,6 @@ updates:
       interval: weekly
     labels:
       - dependencies
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
     groups:
       node:
         patterns:
@@ -37,9 +31,6 @@ updates:
       interval: weekly
     labels:
       - dependencies
-    ignore:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
     groups:
       ci:
         patterns:


### PR DESCRIPTION
This could be useful for some security updates because those are commonly patch updates. I believe we can at least try taking patch updates into account and ignoring only the noisiest ones later.