### PR TITLE
chore: increase cargo cache reuse in ci

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -55,11 +55,13 @@ runs:
       uses: swatinem/rust-cache@v2
       with:
         workspaces: . -> target
+        shared-key: ${{ runner.os }}-${{ runner.arch }}
+        cache-on-failure: true
 
     - name: Install pnpm
       uses: pnpm/action-setup@v4
       with:
-        version: 10
+        version: latest
 
     - name: Node setup and cache
       uses: actions/setup-node@v4


### PR DESCRIPTION
Currently cargo cache is almost never reused, even between jobs in the same PR. Each cache can be 1~2 GB, making the total cache size explode (far over the 10GB limit). This PR tries to reuse across same os and architecture.