### PR TITLE
chore: fix rust cache already appending os and arch to cache key

### DIFF
--- a/.github/actions/setup/action.yaml
+++ b/.github/actions/setup/action.yaml
@@ -16,6 +16,11 @@ inputs:
     type: string
     required: true
     default: ""
+  rust-cache-shared-key:
+    description: The shared-key for swatinem/rust-cache.
+    type: string
+    required: true
+    default: shared
   lint:
     description: Whether to do additional setup for linting.
     type: boolean
@@ -55,7 +60,7 @@ runs:
       uses: swatinem/rust-cache@v2
       with:
         workspaces: . -> target
-        shared-key: ${{ runner.os }}-${{ runner.arch }}
+        shared-key: ${{ inputs.rust-cache-shared-key }}
         cache-on-failure: true
 
     - name: Install pnpm


### PR DESCRIPTION
Currently the cache keys look like: `v0-rust-Linux-X64-Linux-x64-3bcebdd4-db0c8ef2`, you can see the os and arch are duplicated. This is because the cache action is appending these anyways: https://github.com/Swatinem/rust-cache/blob/14cb63c99f59f3218434d76ea30a71214758bc74/src/config.ts#L77