### PR TITLE
chore: use prettier-toml-plugin

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,13 +27,12 @@ jobs:
         with:
           platform: ubuntu-latest
           cache-key: debug
-          tools: taplo
           nightly-rustfmt: true
 
       - uses: ./.github/actions/setup-node
 
       - name: Check formatting
-        run: pnpm format:check && taplo format --check --diff
+        run: pnpm format:check
 
       - name: Regenerate auto-generated files
         run: |

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,5 @@
 pnpm-lock.yaml
+Cargo.lock
 *.ts.hbs
 
 # Auto-generated files

--- a/.taplo.toml
+++ b/.taplo.toml
@@ -1,5 +1,0 @@
-include = ["*.toml", ".cargo/*.toml", "crates/*/*.toml"]
-
-[formatting]
-align_entries = true
-reorder_keys  = true

--- a/package.json
+++ b/package.json
@@ -12,8 +12,6 @@
     "format:js:check": "prettier --check .",
     "format:rs": "cargo +nightly fmt",
     "format:rs:check": "cargo +nightly fmt -- --check",
-    "format:toml": "taplo format",
-    "format:toml:check": "taplo format --check",
     "lint": "pnpm lint:js && pnpm lint:rs",
     "lint:check": "pnpm lint:js:check && pnpm lint:rs:check",
     "lint:js": "oxlint --max-warnings=0 --fix .",
@@ -36,11 +34,18 @@
     "husky": "^9.1.6",
     "lint-staged": "^16.2.0",
     "oxlint": "^1.18.0",
-    "prettier": "^3.6.2"
+    "prettier": "^3.6.2",
+    "prettier-plugin-toml": "^2.0.6"
   },
-  "prettier": {},
+  "prettier": {
+    "plugins": [
+      "prettier-plugin-toml"
+    ],
+    "alignEntries": true,
+    "reorderKeys": true
+  },
   "lint-staged": {
-    "*.{js,jsx,ts,tsx,json,md,mdx,html,css,scss,yml,yaml}": "prettier --write",
+    "*.{js,jsx,ts,tsx,json,md,mdx,html,css,scss,yml,yaml,toml}": "prettier --write",
     "*.{js,jsx,ts,tsx}": "oxlint --fix",
     "*.rs": "rustfmt +nightly --"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
+      prettier-plugin-toml:
+        specifier: ^2.0.6
+        version: 2.0.6(prettier@3.6.2)
 
   docs:
     devDependencies:
@@ -1817,6 +1820,12 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
+  '@taplo/core@0.2.0':
+    resolution: {integrity: sha512-r8bl54Zj1In3QLkiW/ex694bVzpPJ9EhwqT9xkcUVODnVUGirdB1JTsmiIv0o1uwqZiwhi8xNnTOQBRQCpizrQ==}
+
+  '@taplo/lib@0.5.0':
+    resolution: {integrity: sha512-+xIqpQXJco3T+VGaTTwmhxLa51qpkQxCjRwezjFZgr+l21ExlywJFcDfTrNmL6lG6tqb0h8GyJKO3UPGPtSCWg==}
+
   '@tauri-apps/api@2.8.0':
     resolution: {integrity: sha512-ga7zdhbS2GXOMTIZRT0mYjKJtR9fivsXzsyq5U3vjDL0s6DTMwYRm0UHNjzTY5dh4+LSC68Sm/7WEiimbQNYlw==}
 
@@ -2525,6 +2534,12 @@ packages:
 
   preact@10.27.2:
     resolution: {integrity: sha512-5SYSgFKSyhCbk6SrXyMpqjb5+MQBgfvEKE/OC+PujcY34sOpqtr+0AZQtPYx5IA6VxynQ7rUPCtKzyovpj9Bpg==}
+
+  prettier-plugin-toml@2.0.6:
+    resolution: {integrity: sha512-12N/wBuHa9jd/KVy9pRP20NMKxQfQLMseQCt66lIbLaPLItvGUcSIryE1eZZMJ7loSws6Ig3M2Elc2EreNh76w==}
+    engines: {node: '>=16.0.0'}
+    peerDependencies:
+      prettier: ^3.0.3
 
   prettier@3.6.2:
     resolution: {integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==}
@@ -4553,6 +4568,12 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
+  '@taplo/core@0.2.0': {}
+
+  '@taplo/lib@0.5.0':
+    dependencies:
+      '@taplo/core': 0.2.0
+
   '@tauri-apps/api@2.8.0': {}
 
   '@tauri-apps/cli-darwin-arm64@2.8.4':
@@ -5265,6 +5286,11 @@ snapshots:
       source-map-js: 1.2.1
 
   preact@10.27.2: {}
+
+  prettier-plugin-toml@2.0.6(prettier@3.6.2):
+    dependencies:
+      '@taplo/lib': 0.5.0
+      prettier: 3.6.2
 
   prettier@3.6.2: {}
 


### PR DESCRIPTION
`prettier-toml-plugin` internally uses taplo and all options (at least the ones we need) are supported, so it is a drop-in replacement. And there will not be the path issue with wasm from taplo-cli because it uses the internal `@taplo/lib`. This allows everyone to do toml formatting out of the box instead of having to manually install `taplo-cli` and do `pnpm format:toml` separately.