### PR TITLE
fix: scope `RUST_BACKTRACE=1` in ci to avoid affecting cache key computation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,9 +8,6 @@ on:
     branches:
       - main
 
-env:
-  RUST_BACKTRACE: 1
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -36,6 +33,8 @@ jobs:
         run: pnpm format:check && taplo format --check --diff
 
       - name: Regenerate auto-generated files
+        env:
+          RUST_BACKTRACE: 1
         run: |
           pnpm build:packages
           pnpm build:bindings
@@ -98,6 +97,8 @@ jobs:
       - uses: ./.github/actions/setup-node
 
       - name: Run test suite
+        env:
+          RUST_BACKTRACE: 1
         run: pnpm test
 
   ci-build:


### PR DESCRIPTION
It seems that when the `Swatinem/rust-cache@v2` action computes cache key, part of its hash is the environment variables that match the following prefixes `envPrefixes = ["CARGO", "CC", "CFLAGS", "CXX", "CMAKE", "RUST"]`, and `RUST_BACKTRACE` is clearly one of them. Since our cache warmup does not have this environment variable set but our CI workflow does, this will cause the cache to always miss. This PR scopes `RUST_BACKTRACE=1` to only steps that need it (in particular test and rust-based build actions) so that it does not affect the cache key computation step.