### PR TITLE
ci: reuse release cache correctly

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -136,8 +136,8 @@ jobs:
       - name: Build Deskulpt
         id: build-deskulpt
         uses: tauri-apps/tauri-action@v0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          args: --target ${{ matrix.target }}
 
       - name: Upload build artifacts
         id: upload-artifacts


### PR DESCRIPTION
Previously the test build workflow hits the cache, but the compilation still starts from scratch. This is likely because target is not specified (note that when target is specified, the artifacts are in `./target/${TARGET}` even if the target is the default target). Moreover, for the macos case not specifying target is simply wrong.

Another minor change: test build workflow does not and should not need `GITHUB_TOKEN`.