### PR TITLE
chore: add a deskulpt-workspace crate provides workspace paths

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,6 @@
+[env]
+WORKSPACE_DIR = { value = "", relative = true }
+
 [build]
 # https://github.com/rolldown/rolldown/blob/90102d7b7a74319d2838619f504d661fcb9fff73/.cargo/config.toml#L6-L7
 rustflags = ["--cfg", "tracing_unstable"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1054,6 +1054,7 @@ version = "0.0.1"
 dependencies = [
  "deskulpt-core",
  "deskulpt-specta",
+ "deskulpt-workspace",
  "schemars 1.0.4",
  "serde_json",
  "specta",
@@ -1152,6 +1153,10 @@ dependencies = [
  "tauri-specta",
  "thiserror 2.0.17",
 ]
+
+[[package]]
+name = "deskulpt-workspace"
+version = "0.0.1"
 
 [[package]]
 name = "digest"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ deskulpt-macros        = { version = "0.0.1", path = "crates/deskulpt-macros" }
 deskulpt-plugin        = { version = "0.0.1", path = "crates/deskulpt-plugin" }
 deskulpt-plugin-macros = { version = "0.0.1", path = "crates/deskulpt-plugin-macros" }
 deskulpt-specta        = { version = "0.0.1", path = "crates/deskulpt-specta" }
+deskulpt-workspace     = { version = "0.0.1", path = "crates/deskulpt-workspace" }
 
 # TODO: Remove these since they will not be dependencies of other crates when finalized
 deskulpt-plugin-fs  = { version = "0.0.1", path = "crates/deskulpt-plugin-fs" }

--- a/crates/deskulpt-workspace/Cargo.toml
+++ b/crates/deskulpt-workspace/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+description = "Workspace utilities for Deskulpt."
+name        = "deskulpt-workspace"
+
+authors    = { workspace = true }
+edition    = { workspace = true }
+homepage   = { workspace = true }
+license    = { workspace = true }
+repository = { workspace = true }
+version    = { workspace = true }
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--extend-css", "../rustdoc.css"]

--- a/crates/deskulpt-workspace/README.md
+++ b/crates/deskulpt-workspace/README.md
@@ -1,0 +1,3 @@
+This crate implements utilities for managing the repository workspace of [Deskulpt](https://csci-shu-410-se-project.github.io/).
+
+⚠️ This crate is meant to be used internally by the Deskulpt application and is not designed to support plugin authors or other users directly. Private items are documented for reference of Deskulpt developers.

--- a/crates/deskulpt-workspace/src/lib.rs
+++ b/crates/deskulpt-workspace/src/lib.rs
@@ -1,0 +1,36 @@
+#![doc = include_str!("../README.md")]
+#![doc(
+    html_logo_url = "https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/raw/main/packages/deskulpt/public/deskulpt.svg",
+    html_favicon_url = "https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/raw/main/packages/deskulpt/public/deskulpt.svg"
+)]
+
+use std::path::PathBuf;
+
+/// Get the root directory of the workspace.
+pub fn root_dir() -> PathBuf {
+    PathBuf::from(env!("WORKSPACE_DIR"))
+}
+
+/// Get the docs directory of the workspace.
+pub fn docs_dir() -> PathBuf {
+    root_dir().join("docs")
+}
+
+/// Get the directory of a crate in the workspace.
+pub fn crate_dir(crate_name: &str) -> PathBuf {
+    root_dir().join("crates").join(crate_name)
+}
+
+/// Get the directory of a package in the workspace.
+pub fn package_dir(package_name: &str) -> PathBuf {
+    root_dir().join("packages").join(package_name)
+}
+
+#[test]
+fn test_root_dir() {
+    let root_dir = root_dir();
+    assert!(
+        root_dir.join("pnpm-workspace.yaml").exists(),
+        "Incorrect root dir: {root_dir:?}; expected to contain pnpm-workspace.yaml"
+    );
+}

--- a/crates/deskulpt/Cargo.toml
+++ b/crates/deskulpt/Cargo.toml
@@ -20,8 +20,9 @@ tauri-plugin-opener            = { workspace = true }
 tauri-specta                   = { workspace = true }
 
 [dev-dependencies]
-deskulpt-specta = { workspace = true }
-schemars        = { workspace = true }
+deskulpt-specta    = { workspace = true }
+deskulpt-workspace = { workspace = true }
+schemars           = { workspace = true }
 
 [build-dependencies]
 tauri-build = { workspace = true, features = ["codegen"] }

--- a/crates/deskulpt/src/main.rs
+++ b/crates/deskulpt/src/main.rs
@@ -14,7 +14,7 @@ mod export_bindings {
         deskulpt::get_bindings_builder()
             .export(
                 TypeScript::default(),
-                "../../packages/deskulpt/src/bindings.ts",
+                deskulpt_workspace::package_dir("deskulpt").join("src/bindings.ts"),
             )
             .expect("Failed to export TypeScript bindings");
     }
@@ -32,8 +32,8 @@ mod export_schema {
     #[ignore]
     fn export_settings() {
         let schema = schema_for!(Settings);
-        let file = File::create("../../docs/src/public/settings-schema.json")
-            .expect("Failed to create file");
+        let path = deskulpt_workspace::docs_dir().join("src/public/settings-schema.json");
+        let file = File::create(path).expect("Failed to create file");
         let writer = BufWriter::new(file);
         serde_json::to_writer_pretty(writer, &schema).expect("Failed to write schema");
     }


### PR DESCRIPTION
Similar to this: https://github.com/rolldown/rolldown/tree/d8f169266f6604851182a85827dc13089bb6e89a/crates/rolldown_workspace, intended to be used only as dev or build dependencies or internal xtask crates.