### PR TITLE
refactor: add deskulpt-build and helper macros to avoid duplicated claration of commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1195,6 +1195,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "deskulpt-build"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "quote",
+ "syn 2.0.106",
+ "tauri-plugin",
+]
+
+[[package]]
 name = "deskulpt-common"
 version = "0.0.1"
 dependencies = [
@@ -1210,6 +1220,7 @@ name = "deskulpt-core"
 version = "0.0.1"
 dependencies = [
  "anyhow",
+ "deskulpt-build",
  "deskulpt-common",
  "deskulpt-plugin",
  "deskulpt-plugin-fs",
@@ -1228,7 +1239,6 @@ dependencies = [
  "serialize-to-javascript",
  "specta",
  "tauri",
- "tauri-plugin",
  "tauri-plugin-global-shortcut",
  "thiserror 2.0.17",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,7 @@ tokio                          = "1.47.1"
 uuid                           = "1.16.0"
 
 # Deskulpt crates
+deskulpt-build         = { version = "0.0.1", path = "crates/deskulpt-build" }
 deskulpt-common        = { version = "0.0.1", path = "crates/deskulpt-common" }
 deskulpt-core          = { version = "0.0.1", path = "crates/deskulpt-core" }
 deskulpt-macros        = { version = "0.0.1", path = "crates/deskulpt-macros" }

--- a/crates/deskulpt-build/Cargo.toml
+++ b/crates/deskulpt-build/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+description = "Build-time utilities for Deskulpt."
+name        = "deskulpt-build"
+
+authors    = { workspace = true }
+edition    = { workspace = true }
+homepage   = { workspace = true }
+license    = { workspace = true }
+repository = { workspace = true }
+version    = { workspace = true }
+
+[dependencies]
+anyhow       = { workspace = true }
+quote        = { workspace = true }
+syn          = { workspace = true }
+tauri-plugin = { workspace = true, features = ["build"] }
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--extend-css", "../rustdoc.css"]

--- a/crates/deskulpt-build/README.md
+++ b/crates/deskulpt-build/README.md
@@ -1,3 +1,3 @@
-This crate implements built-time utilities for the [Deskulpt](https://csci-shu-410-se-project.github.io/) application.
+This crate implements utilities for managing the repository workspace of [Deskulpt](https://csci-shu-410-se-project.github.io/).
 
 ⚠️ This crate is meant to be used internally by the Deskulpt application and is not designed to support plugin authors or other users directly. Private items are documented for reference of Deskulpt developers.

--- a/crates/deskulpt-build/src/lib.rs
+++ b/crates/deskulpt-build/src/lib.rs
@@ -1,8 +1,15 @@
+#![doc = include_str!("../README.md")]
+#![doc(
+    html_logo_url = "https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/raw/main/packages/deskulpt/public/deskulpt.svg",
+    html_favicon_url = "https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/raw/main/packages/deskulpt/public/deskulpt.svg"
+)]
+
 use std::path::PathBuf;
 
 use anyhow::{anyhow, bail, Context, Result};
 use quote::{format_ident, quote};
 
+/// Builder for build-time configuration of Deskulpt.
 #[derive(Default)]
 pub struct Builder {
     commands: &'static [&'static str],
@@ -31,7 +38,7 @@ impl Builder {
 
     /// Set the module of the commands.
     ///
-    /// If not set, defaults to "crate::commands".
+    /// If not set, defaults to `crate::commands`.
     pub fn commands_mod(&mut self, module: &'static str) -> &mut Self {
         self.commands_mod = Some(module);
         self
@@ -39,14 +46,14 @@ impl Builder {
 
     /// Set the module of the events.
     ///
-    /// If not set, defaults to "crate::events".
+    /// If not set, defaults to `crate::events`.
     pub fn events_mod(&mut self, module: &'static str) -> &mut Self {
         self.events_mod = Some(module);
         self
     }
 
     /// Run the build process, returning an error if it fails.
-    fn try_build(&self) -> Result<()> {
+    pub fn try_build(&self) -> Result<()> {
         let name = env!("CARGO_PKG_NAME");
         if !name.starts_with("deskulpt-") {
             bail!("Plugin crate names must start with 'deskulpt-'; got '{name}'");
@@ -54,9 +61,9 @@ impl Builder {
 
         let commands_mod: syn::Path =
             syn::parse_str(self.commands_mod.unwrap_or("crate::commands"))
-                .with_context(|| format!("Invalid commands_mod"))?;
+                .with_context(|| "Invalid commands_mod".to_string())?;
         let events_mod: syn::Path = syn::parse_str(self.events_mod.unwrap_or("crate::events"))
-            .with_context(|| format!("Invalid events_mod"))?;
+            .with_context(|| "Invalid events_mod".to_string())?;
 
         let commands = self
             .commands

--- a/crates/deskulpt-build/src/lib.rs
+++ b/crates/deskulpt-build/src/lib.rs
@@ -1,0 +1,114 @@
+use std::path::PathBuf;
+
+use anyhow::{anyhow, bail, Context, Result};
+use quote::{format_ident, quote};
+
+#[derive(Default)]
+pub struct Builder {
+    commands: &'static [&'static str],
+    events: &'static [&'static str],
+    commands_mod: Option<&'static str>,
+    events_mod: Option<&'static str>,
+}
+
+impl Builder {
+    /// Set the commands for the builder.
+    ///
+    /// These will be used for configuring the bindings builder and the Tauri
+    /// plugin builder, and for generating plugin initialization code.
+    pub fn commands(&mut self, commands: &'static [&'static str]) -> &mut Self {
+        self.commands = commands;
+        self
+    }
+
+    /// Set the events for the builder.
+    ///
+    /// These will be used for configuring the bindings builder.
+    pub fn events(&mut self, events: &'static [&'static str]) -> &mut Self {
+        self.events = events;
+        self
+    }
+
+    /// Set the module of the commands.
+    ///
+    /// If not set, defaults to "crate::commands".
+    pub fn commands_mod(&mut self, module: &'static str) -> &mut Self {
+        self.commands_mod = Some(module);
+        self
+    }
+
+    /// Set the module of the events.
+    ///
+    /// If not set, defaults to "crate::events".
+    pub fn events_mod(&mut self, module: &'static str) -> &mut Self {
+        self.events_mod = Some(module);
+        self
+    }
+
+    /// Run the build process, returning an error if it fails.
+    fn try_build(&self) -> Result<()> {
+        let name = env!("CARGO_PKG_NAME");
+        if !name.starts_with("deskulpt-") {
+            bail!("Plugin crate names must start with 'deskulpt-'; got '{name}'");
+        }
+
+        let commands_mod: syn::Path =
+            syn::parse_str(self.commands_mod.unwrap_or("crate::commands"))
+                .with_context(|| format!("Invalid commands_mod"))?;
+        let events_mod: syn::Path = syn::parse_str(self.events_mod.unwrap_or("crate::events"))
+            .with_context(|| format!("Invalid events_mod"))?;
+
+        let commands = self
+            .commands
+            .iter()
+            .map(|c| format_ident!("{c}"))
+            .collect::<Vec<_>>();
+        let events = self
+            .events
+            .iter()
+            .map(|e| format_ident!("{e}"))
+            .collect::<Vec<_>>();
+
+        let configure_bindings_builder = quote! {
+            #[doc(hidden)]
+            pub fn configure_bindings_builder(builder: &mut ::deskulpt_common::bindings::BindingsBuilder) {
+                builder
+                    .commands(
+                        env!("CARGO_PKG_NAME"),
+                        ::deskulpt_common::bindings::collect_commands![
+                            #( #commands_mod::#commands::<::tauri::Wry> ),*
+                        ],
+                    )
+                    #( .event::<#events_mod::#events>() )*;
+            }
+        };
+
+        let init_builder = quote! {
+            tauri::plugin::Builder::new(env!("CARGO_PKG_NAME"))
+                .invoke_handler(generate_handler![
+                    #( #commands_mod::#commands ),*
+                ])
+        };
+
+        let out_dir = std::env::var("OUT_DIR").map_err(|_| anyhow!("OUT_DIR not set"))?;
+        let out_dir = PathBuf::from(out_dir);
+
+        std::fs::write(
+            out_dir.join("configure_bindings_builder.rs"),
+            configure_bindings_builder.to_string(),
+        )?;
+
+        std::fs::write(out_dir.join("init_builder.rs"), init_builder.to_string())?;
+
+        tauri_plugin::Builder::new(self.commands).try_build()?;
+        Ok(())
+    }
+
+    /// Same as [`Self::try_build`], but exits automatically on error.
+    pub fn build(&self) {
+        if let Err(error) = self.try_build() {
+            println!("{}: {error:#}", env!("CARGO_PKG_NAME"));
+            std::process::exit(1);
+        }
+    }
+}

--- a/crates/deskulpt-build/src/lib.rs
+++ b/crates/deskulpt-build/src/lib.rs
@@ -84,8 +84,8 @@ impl Builder {
         };
 
         let init_builder = quote! {
-            tauri::plugin::Builder::new(env!("CARGO_PKG_NAME"))
-                .invoke_handler(generate_handler![
+            ::tauri::plugin::Builder::new(env!("CARGO_PKG_NAME"))
+                .invoke_handler(::tauri::generate_handler![
                     #( #commands_mod::#commands ),*
                 ])
         };

--- a/crates/deskulpt-common/src/bindings.rs
+++ b/crates/deskulpt-common/src/bindings.rs
@@ -1,4 +1,4 @@
-//! Common utilities for Deskulpt bindings.
+//! Common utilities for declaring Deskulpt bindings.
 
 use std::collections::BTreeMap;
 
@@ -20,6 +20,9 @@ pub struct Bindings {
 }
 
 /// Builder for a [`Bindings`] instance.
+///
+/// This should never be constructed manually in bindings providers; instead,
+/// configure the build script and use [`configure_bindings_builder!`].
 #[derive(Default)]
 pub struct BindingsBuilder {
     types: TypeCollection,
@@ -70,4 +73,22 @@ impl BindingsBuilder {
 }
 
 /// Used in [`BindingsBuilder::commands`].
+///
+/// <div style="display: none;">
+#[doc(inline)]
 pub use specta::function::collect_functions as collect_commands;
+
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __configure_bindings_builder {
+    () => {
+        include!(concat!(env!("OUT_DIR"), "/configure_bindings_builder.rs"));
+    };
+}
+
+/// Configure a [`BindingsBuilder`] with the commands and events of this crate.
+///
+/// The internals of this function are generated at build time, so one must
+/// configure the build script correctly.
+#[doc(inline)]
+pub use __configure_bindings_builder as configure_bindings_builder;

--- a/crates/deskulpt-common/src/bindings.rs
+++ b/crates/deskulpt-common/src/bindings.rs
@@ -89,6 +89,6 @@ macro_rules! __configure_bindings_builder {
 /// Configure a [`BindingsBuilder`] with the commands and events of this crate.
 ///
 /// The internals of this function are generated at build time, so one must
-/// configure the build script correctly.
+/// configure the build script correctly with `deskulpt-build`.
 #[doc(inline)]
 pub use __configure_bindings_builder as configure_bindings_builder;

--- a/crates/deskulpt-common/src/event.rs
+++ b/crates/deskulpt-common/src/event.rs
@@ -1,8 +1,6 @@
 //! Common utilities for Deskulpt events.
 
 use anyhow::Result;
-/// Derive the [`Event`] trait for a struct.
-pub use deskulpt_macros::Event;
 use serde::Serialize;
 use tauri::{Emitter, Runtime};
 
@@ -35,3 +33,6 @@ pub trait Event: specta::Type + Serialize {
         Ok(())
     }
 }
+
+/// Derive the [`Event`] trait for a struct.
+pub use deskulpt_macros::Event;

--- a/crates/deskulpt-common/src/init.rs
+++ b/crates/deskulpt-common/src/init.rs
@@ -10,6 +10,7 @@ macro_rules! __init_builder {
 ///
 /// The builder has its name automatically set to the crate name, and its
 /// invoke handler set to the commands specified in the build script. It can be
-/// further customized before calling the `.build()` method.
+/// further customized before calling the `.build()` method. One must configure
+/// the build script correctly with `deskulpt-build`.
 #[doc(inline)]
 pub use __init_builder as init_builder;

--- a/crates/deskulpt-common/src/init.rs
+++ b/crates/deskulpt-common/src/init.rs
@@ -1,0 +1,15 @@
+#[doc(hidden)]
+#[macro_export]
+macro_rules! __init_builder {
+    () => {
+        include!(concat!(env!("OUT_DIR"), "/init_builder.rs"));
+    };
+}
+
+/// Initialize a [`tauri::plugin::Builder`].
+///
+/// The builder has its name automatically set to the crate name, and its
+/// invoke handler set to the commands specified in the build script. It can be
+/// further customized before calling the `.build()` method.
+#[doc(inline)]
+pub use __init_builder as init_builder;

--- a/crates/deskulpt-common/src/lib.rs
+++ b/crates/deskulpt-common/src/lib.rs
@@ -6,4 +6,5 @@
 
 pub mod bindings;
 pub mod event;
+pub mod init;
 pub mod window;

--- a/crates/deskulpt-core/Cargo.toml
+++ b/crates/deskulpt-core/Cargo.toml
@@ -45,7 +45,7 @@ deskulpt-plugin-sys = { workspace = true }
 objc2 = { workspace = true }
 
 [build-dependencies]
-tauri-plugin = { workspace = true }
+deskulpt-build = { workspace = true }
 
 [package.metadata.docs.rs]
 rustdoc-args = ["--extend-css", "../rustdoc.css"]

--- a/crates/deskulpt-core/build.rs
+++ b/crates/deskulpt-core/build.rs
@@ -1,14 +1,22 @@
-const COMMANDS: &[&str] = &[
-    "bundle_widget",
-    "call_plugin",
-    "emit_on_render_ready",
-    "exit_app",
-    "open_widget",
-    "rescan_widgets",
-    "set_render_ready",
-    "update_settings",
-];
-
 fn main() {
-    tauri_plugin::Builder::new(COMMANDS).build();
+    deskulpt_build::Builder::default()
+        .commands(&[
+            "bundle_widget",
+            "call_plugin",
+            "emit_on_render_ready",
+            "exit_app",
+            "open_widget",
+            "rescan_widgets",
+            "set_render_ready",
+            "update_settings",
+        ])
+        .events(&[
+            "ExitAppEvent",
+            "RemoveWidgetsEvent",
+            "RenderWidgetsEvent",
+            "ShowToastEvent",
+            "SwitchThemeEvent",
+            "UpdateSettingsEvent",
+        ])
+        .build();
 }

--- a/crates/deskulpt-core/src/lib.rs
+++ b/crates/deskulpt-core/src/lib.rs
@@ -4,7 +4,7 @@
     html_favicon_url = "https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/raw/main/packages/deskulpt/public/deskulpt.svg"
 )]
 
-use tauri::plugin::{Builder, TauriPlugin};
+use tauri::plugin::TauriPlugin;
 use tauri::{generate_handler, Runtime};
 
 mod bundler;
@@ -17,47 +17,14 @@ pub mod states;
 pub mod tray;
 pub mod window;
 
+deskulpt_common::bindings::configure_bindings_builder!();
+
 /// Initialize the `deskulpt-core` plugin.
 pub fn init<R: Runtime>() -> TauriPlugin<R> {
-    Builder::new("deskulpt-core")
-        .invoke_handler(generate_handler![
-            commands::bundle_widget,
-            commands::call_plugin,
-            commands::emit_on_render_ready,
-            commands::exit_app,
-            commands::open_widget,
-            commands::rescan_widgets,
-            commands::set_render_ready,
-            commands::update_settings,
-        ])
-        .build()
+    deskulpt_common::init::init_builder!().build()
 }
 
 /// Re-exports for JSON schema generation.
 pub mod schema {
     pub use crate::settings::Settings;
-}
-
-#[doc(hidden)]
-pub fn configure_bindings_builder(builder: &mut deskulpt_common::bindings::BindingsBuilder) {
-    builder
-        .commands(
-            "deskulpt-core",
-            deskulpt_common::bindings::collect_commands![
-                commands::bundle_widget::<tauri::Wry>,
-                commands::call_plugin::<tauri::Wry>,
-                commands::emit_on_render_ready::<tauri::Wry>,
-                commands::exit_app::<tauri::Wry>,
-                commands::open_widget::<tauri::Wry>,
-                commands::rescan_widgets::<tauri::Wry>,
-                commands::set_render_ready::<tauri::Wry>,
-                commands::update_settings::<tauri::Wry>,
-            ],
-        )
-        .event::<events::ExitAppEvent>()
-        .event::<events::RemoveWidgetsEvent>()
-        .event::<events::RenderWidgetsEvent>()
-        .event::<events::ShowToastEvent>()
-        .event::<events::SwitchThemeEvent>()
-        .event::<events::UpdateSettingsEvent>();
 }

--- a/crates/deskulpt-core/src/lib.rs
+++ b/crates/deskulpt-core/src/lib.rs
@@ -5,7 +5,7 @@
 )]
 
 use tauri::plugin::TauriPlugin;
-use tauri::{generate_handler, Runtime};
+use tauri::Runtime;
 
 mod bundler;
 mod commands;

--- a/crates/deskulpt-core/src/lib.rs
+++ b/crates/deskulpt-core/src/lib.rs
@@ -19,7 +19,7 @@ pub mod window;
 
 deskulpt_common::bindings::configure_bindings_builder!();
 
-/// Initialize the `deskulpt-core` plugin.
+/// Initialize the plugin.
 pub fn init<R: Runtime>() -> TauriPlugin<R> {
     deskulpt_common::init::init_builder!().build()
 }


### PR DESCRIPTION
Towards #533.

Now each plugin never needs to specify their plugin names and their commands/events. They do it only once in the build script:

```rs
fn main() {
    deskulpt_build::Builder::default()
        .commands(&[
            "bundle_widget",
            "call_plugin",
            "emit_on_render_ready",
            "exit_app",
            "open_widget",
            "rescan_widgets",
            "set_render_ready",
            "update_settings",
        ])
        .events(&[
            "ExitAppEvent",
            "RemoveWidgetsEvent",
            "RenderWidgetsEvent",
            "ShowToastEvent",
            "SwitchThemeEvent",
            "UpdateSettingsEvent",
        ])
        .build();
}
```

Then in their `lib.rs` they simply need to do:

```rs
// This automatically generates the configure_bindings_builder function
// for use by xtask-gen
deskulpt_common::bindings::configure_bindings_builder!();

pub fn init<R: Runtime>() -> TauriPlugin<R> {
    deskulpt_common::init::init_builder!()
        // Put any further configurations of the builder here, but one
        // no longer needs to configure invoke_handler, and no longer
        // needs to manually set the plugin name
        .build()
}
```