### PR TITLE
refactor: use widget directory name as widget id

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1242,7 +1242,6 @@ dependencies = [
  "tauri-plugin-global-shortcut",
  "thiserror 2.0.17",
  "tokio",
- "uuid",
 ]
 
 [[package]]
@@ -5466,12 +5465,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1_smol"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
-
-[[package]]
 name = "sha2"
 version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6794,7 +6787,6 @@ dependencies = [
  "getrandom 0.3.1",
  "js-sys",
  "serde",
- "sha1_smol",
  "wasm-bindgen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,6 @@ tauri-plugin-global-shortcut   = "2.3.0"
 tauri-plugin-opener            = "2.5.0"
 thiserror                      = "2.0.17"
 tokio                          = "1.47.1"
-uuid                           = "1.16.0"
 
 # Deskulpt crates
 deskulpt-build         = { version = "0.0.1", path = "crates/deskulpt-build" }

--- a/crates/deskulpt-core/Cargo.toml
+++ b/crates/deskulpt-core/Cargo.toml
@@ -28,7 +28,6 @@ specta                       = { workspace = true, features = ["derive", "functi
 tauri-plugin-global-shortcut = { workspace = true }
 thiserror                    = { workspace = true }
 tokio                        = { workspace = true }
-uuid                         = { workspace = true, features = ["v5"] }
 
 tauri = { workspace = true, features = [
   "specta",

--- a/crates/deskulpt-core/src/commands/bundle_widget.rs
+++ b/crates/deskulpt-core/src/commands/bundle_widget.rs
@@ -30,18 +30,16 @@ pub async fn bundle_widget<R: Runtime>(
             .get(&id)
             .ok_or_else(|| cmderr!("Widget (id={}) does not exist", id))?
         {
-            WidgetConfig::Valid {
-                dir, deskulpt_conf, ..
-            } => {
+            WidgetConfig::Ok { entry, .. } => {
                 let builder = WidgetBundlerBuilder::new(
-                    widgets_dir.join(dir),
-                    deskulpt_conf.entry.clone(),
+                    widgets_dir.join(&id),
+                    entry.clone(),
                     base_url,
                     apis_blob_url,
                 );
                 Ok(builder.build())
             },
-            WidgetConfig::Invalid { error, .. } => Err(cmderr!(error.clone())),
+            WidgetConfig::Err { error } => Err(cmderr!(error.clone())),
         }
     })?;
 

--- a/crates/deskulpt-core/src/commands/call_plugin.rs
+++ b/crates/deskulpt-core/src/commands/call_plugin.rs
@@ -3,7 +3,7 @@ use tauri::{command, AppHandle, Runtime};
 use tokio::sync::Mutex;
 
 use super::error::{cmdbail, CmdResult};
-use crate::states::WidgetConfigMapStateExt;
+use crate::path::PathExt;
 
 // TODO: Remove this temporary implementation
 static FS_PLUGIN: Lazy<Mutex<deskulpt_plugin_fs::FsPlugin>> =

--- a/crates/deskulpt-core/src/commands/open_widget.rs
+++ b/crates/deskulpt-core/src/commands/open_widget.rs
@@ -2,7 +2,6 @@ use tauri::{command, AppHandle, Runtime};
 
 use super::error::CmdResult;
 use crate::path::PathExt;
-use crate::states::WidgetConfigMapStateExt;
 
 /// Open the widgets directory or a specific widget directory.
 ///
@@ -23,7 +22,7 @@ pub async fn open_widget<R: Runtime>(
     let widgets_dir = app_handle.widgets_dir()?;
 
     if let Some(id) = id {
-        let widget_dir = app_handle.widget_dir(id)?;
+        let widget_dir = app_handle.widget_dir(&id)?;
         open::that_detached(widget_dir)?;
     } else {
         open::that_detached(widgets_dir)?;

--- a/crates/deskulpt-core/src/commands/rescan_widgets.rs
+++ b/crates/deskulpt-core/src/commands/rescan_widgets.rs
@@ -36,7 +36,10 @@ pub async fn rescan_widgets<R: Runtime>(
         }
 
         if let Some(widget_config) = WidgetConfig::load(&path) {
-            let id = widget_config.id();
+            // Since each widget must be at the top level of the widgets
+            // directory, the directory names must be unique and we can use
+            // them as widget IDs
+            let id = entry.file_name().to_string_lossy().to_string();
             new_config_map.insert(id, widget_config);
         }
     }

--- a/crates/deskulpt-core/src/path.rs
+++ b/crates/deskulpt-core/src/path.rs
@@ -55,6 +55,11 @@ pub trait PathExt<R: Runtime>: Manager<R> {
         Ok(widgets_dir)
     }
 
+    /// Get a reference to a widget directory.
+    fn widget_dir(&self, id: &str) -> Result<PathBuf> {
+        Ok(self.widgets_dir()?.join(id))
+    }
+
     /// Initialize the persistence directory.
     ///
     /// This will create the persistence directory if it does not exist. It must

--- a/crates/deskulpt-core/src/states/widget_config_map.rs
+++ b/crates/deskulpt-core/src/states/widget_config_map.rs
@@ -1,10 +1,8 @@
 //! State management for the widget configuration map.
 
 use std::collections::HashMap;
-use std::path::PathBuf;
 use std::sync::RwLock;
 
-use anyhow::{anyhow, Result};
 use tauri::{App, AppHandle, Manager, Runtime};
 
 use crate::config::WidgetConfig;
@@ -19,23 +17,6 @@ pub trait WidgetConfigMapStateExt<R: Runtime>: Manager<R> + PathExt<R> {
     /// Initialize state management for the widget configuration map.
     fn manage_widget_config_map(&self) {
         self.manage(WidgetConfigMapState::default());
-    }
-
-    /// Get the directory of a widget by ID.
-    ///
-    /// This will error if the widgets directory cannot be accessed or if the
-    /// widget is not found in the collection.
-    fn widget_dir<S: AsRef<str>>(&self, id: S) -> Result<PathBuf> {
-        let widgets_dir = self.widgets_dir()?;
-        let id = id.as_ref();
-
-        let state = self.state::<WidgetConfigMapState>();
-        let widget_config_map = state.0.read().unwrap();
-        let widget_config = widget_config_map
-            .get(id)
-            .ok_or_else(|| anyhow!("Widget {id} not found in the collection"))?;
-
-        Ok(widgets_dir.join(widget_config.dir()))
     }
 
     /// Provide reference to the widget configuration map within a closure.

--- a/packages/deskulpt/src/bindings.ts
+++ b/packages/deskulpt/src/bindings.ts
@@ -21,25 +21,6 @@ theme: Theme;
 shortcuts: Partial<{ [key in ShortcutKey]: string }> }
 
 /**
- * Deserialized `deskulpt.conf.json`.
- */
-export type DeskulptConf = { 
-/**
- * The name of the widget.
- * 
- * This is purely used for display purposes. It does not need to be related
- * to the widget directory name, and it does not need to be unique.
- */
-name: string; 
-/**
- * The entry point of the widget.
- * 
- * This is the path to the file that exports the widget component. The path
- * should be relative to the widget directory.
- */
-entry: string }
-
-/**
  * Deskulpt window enum.
  */
 export type DeskulptWindow = 
@@ -61,11 +42,6 @@ export type DeskulptWindow =
 export type ExitAppEvent = null
 
 export type JsonValue = null | boolean | number | string | JsonValue[] | { [key in string]: JsonValue }
-
-/**
- * Deserialized `package.json`.
- */
-export type PackageJson = { dependencies?: { [key in string]: string } }
 
 /**
  * Event for removing widgets.
@@ -220,13 +196,13 @@ opacity?: number }
  */
 export type WidgetConfig = 
 /**
- * Valid widget configuration.
+ * Valid configuration of a widget.
  */
-{ type: "valid"; dir: string; deskulptConf: DeskulptConf; packageJson: PackageJson | null } | 
+{ type: "ok"; name: string; entry: string; dependencies: { [key in string]: string } } | 
 /**
- * Invalid widget configuration.
+ * Error information if a widget failed to load.
  */
-{ type: "invalid"; dir: string; error: string }
+{ type: "err"; error: string }
 
 /**
  * Per-widget settings.

--- a/packages/deskulpt/src/manager/components/Widgets/Config.tsx
+++ b/packages/deskulpt/src/manager/components/Widgets/Config.tsx
@@ -23,23 +23,21 @@ const Config = memo(({ id }: ConfigProps) => {
   return (
     <ScrollArea asChild>
       <Box height="200px" pr="3" pb="3">
-        {config.type === "valid" ? (
+        {config.type === "ok" ? (
           <Table.Root size="1" layout="fixed" css={styles.table}>
             <Table.Body>
               <Table.Row align="center">
                 <Table.RowHeaderCell>Name</Table.RowHeaderCell>
-                <Table.Cell>{config.deskulptConf.name}</Table.Cell>
+                <Table.Cell>{config.name}</Table.Cell>
               </Table.Row>
               <Table.Row align="center">
                 <Table.RowHeaderCell>Entry</Table.RowHeaderCell>
-                <Table.Cell>{config.deskulptConf.entry}</Table.Cell>
+                <Table.Cell>{config.entry}</Table.Cell>
               </Table.Row>
               <Table.Row align="center">
                 <Table.RowHeaderCell>Dependencies</Table.RowHeaderCell>
                 <Table.Cell>
-                  <Dependencies
-                    dependencies={config.packageJson?.dependencies}
-                  />
+                  <Dependencies dependencies={config.dependencies} />
                 </Table.Cell>
               </Table.Row>
             </Table.Body>

--- a/packages/deskulpt/src/manager/components/Widgets/Dependencies.tsx
+++ b/packages/deskulpt/src/manager/components/Widgets/Dependencies.tsx
@@ -12,12 +12,11 @@ const styles = {
 };
 
 interface DependenciesProps {
-  dependencies?: Record<string, string>;
+  dependencies: Record<string, string>;
 }
 
 const Dependencies = memo(({ dependencies }: DependenciesProps) => {
-  const dependenciesArray =
-    dependencies === undefined ? [] : Object.entries(dependencies);
+  const dependenciesArray = Object.entries(dependencies);
 
   return dependenciesArray.length > 0 ? (
     <Popover.Root>

--- a/packages/deskulpt/src/manager/components/Widgets/Header.tsx
+++ b/packages/deskulpt/src/manager/components/Widgets/Header.tsx
@@ -24,7 +24,7 @@ const Header = memo(({ id }: HeaderProps) => {
 
   return (
     <Flex align="center" justify="between">
-      <Badge color={type === "valid" ? "gray" : "red"}>ID: {id}</Badge>
+      <Badge color={type === "ok" ? "gray" : "red"}>ID: {id}</Badge>
       <Flex align="center" gap="2">
         <Button
           title="Refresh this widget"

--- a/packages/deskulpt/src/manager/components/Widgets/Trigger.tsx
+++ b/packages/deskulpt/src/manager/components/Widgets/Trigger.tsx
@@ -40,10 +40,10 @@ const Trigger = memo(({ id, value }: TriggerProps) => {
           height="6px"
           css={[
             styles.indicator,
-            config.type === "invalid" && styles.indicatorInvalid,
+            config.type === "err" && styles.indicatorInvalid,
           ]}
         />
-        <Text>{config.dir}</Text>
+        <Text>{id}</Text>
       </Flex>
     </Tabs.Trigger>
   );

--- a/packages/deskulpt/src/manager/hooks/useWidgetsStore.ts
+++ b/packages/deskulpt/src/manager/hooks/useWidgetsStore.ts
@@ -53,9 +53,7 @@ export async function rescan(initial: boolean = false) {
   // Sort widgets by their directory name
   useWidgetsStore.setState({
     widgets: Object.fromEntries(
-      widgetsArray.toSorted(([, a], [, b]) =>
-        a.config.dir.localeCompare(b.config.dir),
-      ),
+      widgetsArray.toSorted(([a], [b]) => a.localeCompare(b)),
     ),
   });
 


### PR DESCRIPTION
There is no reason to compute a deterministic uuid based on widget directory name as the widget id just to make it not human-readable. By design we can be sure that widget directory names are unique already. Moreover, there are cases where we want them to be human-readable, e.g., editing settings.json file (though this is rare case).