### PR TITLE
ci: add .gitattributes with eol=lf and pipeline ci more reasonably

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,4 @@
+root = true
+
+[*]
+end_of_line = lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text eol=lf
+
+*.png -text
+*.ico -text
+*.icns -text

--- a/.github/workflows/cache-warmup.yaml
+++ b/.github/workflows/cache-warmup.yaml
@@ -30,8 +30,8 @@ jobs:
       - name: Populate Rust cache
         run: |
           cargo check
-          cargo test --no-run
           cargo build
+          cargo test --no-run
 
   cache-release:
     strategy:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  ci-repo-check:
+  # Prechecks should be kept cheap and platform-agnostic; they block the CI
+  # pipeline if they fail
+  ci-precheck:
     runs-on: ubuntu-latest
 
     steps:
@@ -35,17 +37,17 @@ jobs:
       - name: Check unused cargo dependencies
         run: cargo shear
 
-      - name: Regenerate auto-generated files
+      - name: Check that auto-generated files are up-to-date
         env:
           RUST_BACKTRACE: 1
+        shell: bash
         run: |
+          # Re-generate auto-generated files
           pnpm build:packages
           pnpm build:schema
           cargo gen bindings
 
-      - name: Check that auto-generated files are up to date
-        shell: bash
-        run: |
+          # Check that there are no uncommitted changes
           set -euo pipefail
           if [ -n "$(git status --porcelain)" ]; then
             echo "::error::Auto-generated files are out of date"
@@ -61,7 +63,10 @@ jobs:
             exit 1
           fi
 
-  ci-lint:
+  # Checks that do not fit into precheck, either because they are too expensive
+  # or because they are platform-specific; they do not block the CI pipeline
+  ci-check:
+    needs: [ci-precheck]
     strategy:
       fail-fast: false
       matrix:
@@ -80,26 +85,8 @@ jobs:
 
       - uses: ./.github/actions/setup-node
 
-      - name: Lint codebase
+      - name: Check linting
         run: pnpm lint:check
-
-  ci-test:
-    strategy:
-      fail-fast: false
-      matrix:
-        platform: [macos-latest, ubuntu-latest, windows-latest]
-    runs-on: ${{ matrix.platform }}
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
-
-      - uses: ./.github/actions/setup-rust
-        with:
-          platform: ${{ matrix.platform }}
-          cache-key: debug
-
-      - uses: ./.github/actions/setup-node
 
       - name: Run test suite
         env:
@@ -107,6 +94,7 @@ jobs:
         run: pnpm test
 
   ci-build:
+    needs: [ci-precheck]
     strategy:
       fail-fast: false
       matrix:
@@ -145,3 +133,12 @@ jobs:
         with:
           name: binaries-${{ matrix.platform }}-${{ matrix.target }}
           path: "${{ join(fromJSON(steps.build-deskulpt.outputs.artifactPaths), '\n') }}"
+
+  ci-conclude:
+    needs: [ci-precheck, ci-check, ci-build]
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Conclude
+        shell: bash
+        run: echo "✅ CI pipeline completed successfully!"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Prechecks should be kept cheap and platform-agnostic; they block the CI
+  # Prechecks should be kept cheap and platform-independent; they block the CI
   # pipeline if they fail
   ci-precheck:
     runs-on: ubuntu-latest
@@ -64,7 +64,7 @@ jobs:
           fi
 
   # Checks that do not fit into precheck, either because they are too expensive
-  # or because they are platform-specific; they do not block the CI pipeline
+  # or because they are platform-dependent; they do not block the CI pipeline
   ci-check:
     needs: [ci-precheck]
     strategy:


### PR DESCRIPTION
This PR does the following:

- Configure EOL to always use `lf`. I'm not sure if this would work though. The problems are these: (1) on Windows locally running prettier (and some other tools) will cause a bunch of changes (that will go away once staged, but looks messy); (2) though we does not have jobs that will fail on Windows CI currently (because formatting is run on Linux only), this could be a problem if we have such in future.
- Re-group CI into `ci-precheck`, `ci-check`, and `ci-build`:
  - `ci-precheck` is run on Linux only and runs formatting, cargo shear, and re-generating auto-generated files. These are fast (relatively) and are platform-independent.
  - `ci-check` depends on `ci-precheck` and runs lints and tests. Lints are platform-dependent so it does not fit into precheck. Tests should theoretically be expensive and are also platform-dependent.
  - `ci-build` also depends on `ci-precheck` (but not `ci-check` because `ci-check` can be slow).
  - `ci-conclude` is a single tiny job that depends on all and passes if all passes. It is purely used so that branch protection rule can require only one single job to pass and we can also more easily change the details and namings of the CI jobs in the future.