### PR TITLE
ci: reduce cache size by stripping line-tables-only in debug profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,10 @@ deskulpt-plugin-sys = { version = "0.0.1", path = "crates/deskulpt-plugin-sys" }
 sysinfo             = "0.33.1"
 
 [profile.dev]
-incremental = true
+debug = "line-tables-only"
+
+[profile.test]
+debug = "line-tables-only"
 
 [profile.release]
 codegen-units = 1


### PR DESCRIPTION
As described in the title. Without this, currently the total cache size in one pass is slightly larger than the 10GB limit. Stripping debug symbols should greatly reduce cache size. Note that it would increase the build speed a little bit in local development as well. I don't think there are a lot of cases where we really need full debug info. Even if so, we can specify `RUSTFLAGS="-C debuginfo=2"` when running in those specific debugging cases.