### PR TITLE
ci: completely remove release cache and disable release build in pr workflow

### DIFF
--- a/.github/actions/setup-rust/action.yaml
+++ b/.github/actions/setup-rust/action.yaml
@@ -64,11 +64,12 @@ runs:
         targets: ${{ inputs.targets }}
 
     - name: Setup cache
-      uses: swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@v2
       with:
         workspaces: . -> target
         shared-key: ${{ inputs.cache-key }}
         save-if: ${{ inputs.save-cache == 'true' }}
+        cache-bin: false
 
     - name: Install nightly rustfmt
       if: ${{ inputs.nightly-rustfmt }}

--- a/.github/actions/setup-rust/action.yaml
+++ b/.github/actions/setup-rust/action.yaml
@@ -40,6 +40,9 @@ inputs:
     type: string
     required: true
     default: ""
+    options:
+      - "" # Empty string never hits any cache, effectively disabling caching
+      - debug
 
   save-cache:
     description: Whether to save the cache.

--- a/.github/workflows/cache-warmup.yaml
+++ b/.github/workflows/cache-warmup.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -36,15 +37,7 @@ jobs:
   cache-release:
     strategy:
       matrix:
-        include:
-          - platform: macos-latest
-            target: aarch64-apple-darwin
-          - platform: macos-latest
-            target: x86_64-apple-darwin
-          - platform: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-          - platform: windows-latest
-            target: x86_64-pc-windows-msvc
+        platform: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -54,11 +47,10 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           platform: ${{ matrix.platform }}
-          targets: ${{ matrix.target }}
-          cache-key: release-${{ matrix.target }}
+          cache-key: release
           save-cache: true
 
       - uses: ./.github/actions/setup-node
 
       - name: Populate Rust cache
-        run: pnpm tauri build --target ${{ matrix.target }} --no-bundle
+        run: pnpm tauri build --no-bundle

--- a/.github/workflows/cache-warmup.yaml
+++ b/.github/workflows/cache-warmup.yaml
@@ -33,24 +33,3 @@ jobs:
           cargo check
           cargo build
           cargo test --no-run
-
-  cache-release:
-    strategy:
-      matrix:
-        platform: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{ matrix.platform }}
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
-
-      - uses: ./.github/actions/setup-rust
-        with:
-          platform: ${{ matrix.platform }}
-          cache-key: release
-          save-cache: true
-
-      - uses: ./.github/actions/setup-node
-
-      - name: Populate Rust cache
-        run: pnpm tauri build --no-bundle

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -94,15 +94,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - platform: macos-latest
-            target: aarch64-apple-darwin
-          - platform: macos-latest
-            target: x86_64-apple-darwin
-          - platform: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-          - platform: windows-latest
-            target: x86_64-pc-windows-msvc
+        platform: [macos-latest, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -112,22 +104,19 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           platform: ${{ matrix.platform }}
-          targets: ${{ matrix.target }}
-          cache-key: release-${{ matrix.target }}
+          cache-key: release
 
       - uses: ./.github/actions/setup-node
 
       - name: Build Deskulpt
         id: build-deskulpt
         uses: tauri-apps/tauri-action@v0
-        with:
-          args: --target ${{ matrix.target }}
 
       - name: Upload build artifacts
         id: upload-artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: binaries-${{ matrix.platform }}-${{ matrix.target }}
+          name: binaries-${{ matrix.platform }}
           path: "${{ join(fromJSON(steps.build-deskulpt.outputs.artifactPaths), '\n') }}"
 
   ci-conclude:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,13 +7,13 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  # Cheap OS-agnostic checks
   ci-hygiene:
     runs-on: ubuntu-latest
 
@@ -62,7 +62,6 @@ jobs:
             exit 1
           fi
 
-  # Platform-dependent checks
   ci-verify:
     strategy:
       fail-fast: false
@@ -85,16 +84,30 @@ jobs:
       - name: Check linting
         run: pnpm lint:check
 
-      - name: Run test suite
+      - name: Check build
+        run: |
+          pnpm --filter deskulpt build
+          cargo build -p deskulpt --bins
+
+      - name: Check tests
         env:
           RUST_BACKTRACE: 1
         run: pnpm test
 
   ci-build:
+    if: github.event_name != 'pull_request' || contains(github.event.head_commit.message, '[ci-build]')
     strategy:
       fail-fast: false
       matrix:
-        platform: [macos-latest, ubuntu-latest, windows-latest]
+        include:
+          - platform: macos-latest
+            target: aarch64-apple-darwin
+          - platform: macos-latest
+            target: x86_64-apple-darwin
+          - platform: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - platform: windows-latest
+            target: x86_64-pc-windows-msvc
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -104,7 +117,7 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           platform: ${{ matrix.platform }}
-          cache-key: release
+          targets: ${{ matrix.target }}
 
       - uses: ./.github/actions/setup-node
 
@@ -120,7 +133,7 @@ jobs:
           path: "${{ join(fromJSON(steps.build-deskulpt.outputs.artifactPaths), '\n') }}"
 
   ci-conclude:
-    needs: [ci-hygiene, ci-verify, ci-build]
+    needs: [ci-hygiene, ci-verify]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -124,12 +124,14 @@ jobs:
       - name: Build Deskulpt
         id: build-deskulpt
         uses: tauri-apps/tauri-action@v0
+        with:
+          args: --target ${{ matrix.target }}
 
       - name: Upload build artifacts
         id: upload-artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: binaries-${{ matrix.platform }}
+          name: binaries-${{ matrix.platform }}-${{ matrix.target }}
           path: "${{ join(fromJSON(steps.build-deskulpt.outputs.artifactPaths), '\n') }}"
 
   ci-conclude:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,7 +12,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: [macos-latest, ubuntu-latest, windows-latest]
+        include:
+          - platform: macos-latest
+            target: aarch64-apple-darwin
+          - platform: macos-latest
+            target: x86_64-apple-darwin
+          - platform: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - platform: windows-latest
+            target: x86_64-pc-windows-msvc
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -22,7 +30,7 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           platform: ${{ matrix.platform }}
-          cache-key: release
+          targets: ${{ matrix.target }}
 
       - uses: ./.github/actions/setup-node
 
@@ -30,6 +38,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
+          args: --target ${{ matrix.target }}
           tagName: v__VERSION__
           releaseName: "Deskulpt v__VERSION__"
           releaseDraft: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,15 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        include:
-          - platform: macos-latest
-            target: aarch64-apple-darwin
-          - platform: macos-latest
-            target: x86_64-apple-darwin
-          - platform: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-          - platform: windows-latest
-            target: x86_64-pc-windows-msvc
+        platform: [macos-latest, ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -30,8 +22,7 @@ jobs:
       - uses: ./.github/actions/setup-rust
         with:
           platform: ${{ matrix.platform }}
-          targets: ${{ matrix.target }}
-          cache-key: release-${{ matrix.target }}
+          cache-key: release
 
       - uses: ./.github/actions/setup-node
 
@@ -39,22 +30,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          args: --target ${{ matrix.target }}
           tagName: v__VERSION__
           releaseName: "Deskulpt v__VERSION__"
           releaseDraft: true
           prerelease: false
-          releaseBody: |
-            ## Download Deskulpt v__VERSION__
-
-            | Platform              | Format        | Download                                                                                                                                                      |
-            |-----------------------|---------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|
-            | Linux                 | RPM package   | [Deskulpt-__VERSION__-1.x86_64.rpm](https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/releases/download/v__VERSION__/Deskulpt-__VERSION__-1.x86_64.rpm)     |
-            | Linux                 | DEB package   | [Deskulpt___VERSION___amd64.deb](https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/releases/download/v__VERSION__/Deskulpt___VERSION___amd64.deb)           |
-            | Linux                 | AppImage      | [Deskulpt___VERSION___amd64.AppImage](https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/releases/download/v__VERSION__/Deskulpt___VERSION___amd64.AppImage) |
-            | macOS (Apple Silicon) | DMG installer | [Deskulpt___VERSION___aarch64.dmg](https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/releases/download/v__VERSION__/Deskulpt___VERSION___aarch64.dmg)       |
-            | macOS (Apple Silicon) | Tarball       | [Deskulpt_aarch64.app.tar.gz](https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/releases/download/v__VERSION__/Deskulpt_aarch64.app.tar.gz)                 |
-            | macOS (Intel)         | DMG installer | [Deskulpt___VERSION___x64.dmg](https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/releases/download/v__VERSION__/Deskulpt___VERSION___x64.dmg)               |
-            | macOS (Intel)         | Tarball       | [Deskulpt_x64.app.tar.gz](https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/releases/download/v__VERSION__/Deskulpt_x64.app.tar.gz)                         |
-            | Windows               | MSI installer | [Deskulpt___VERSION___x64_en-US.msi](https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/releases/download/v__VERSION__/Deskulpt___VERSION___x64_en-US.msi)   |
-            | Windows               | EXE installer | [Deskulpt___VERSION___x64-setup.exe](https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/releases/download/v__VERSION__/Deskulpt___VERSION___x64-setup.exe)   |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,8 @@ jobs:
 
       - uses: ./.github/actions/setup-node
 
-      - uses: tauri-apps/tauri-action@v0
+      - name: Build Deskulpt
+        uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
- Do not cache release at all. This saves ~3GB of cache from the 10GB cache limit. Also this means that when our dependencies and crates increase in the future, we get 3x cache size increase rather than 6x.
- In normal PR workflow, disable ci-build completely. Add seperate frontend and backend builds in ci-verify instead. ci-build can still be triggered in PR via `[ci-build]` in commit message, but note that it would have no cache so pretty slow. ci-conclude will not depend on ci-build so that normal PRs can still pass quickly.