### PR TITLE
chore: cargo docs alias and some script/ci cleanup

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,6 @@
 [alias]
-gen = "run --bin xtask-gen --"
+docs = "doc --workspace --no-deps --exclude xtask-gen"
+gen  = "run --bin xtask-gen --"
 
 [env]
 WORKSPACE_DIR = { value = "", relative = true }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -115,6 +115,9 @@ jobs:
       - name: Check linting
         run: pnpm lint:check
 
+      # We do not use Tauri CLI here because it adds the tauri/custom-protocol
+      # feature flag which causes cache misses and longer build times; instead,
+      # a plain `cargo build` is sufficient for CI verification
       - name: Check build
         run: |
           pnpm --filter deskulpt build

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Build rustdoc
         run: |
-          pnpm docs:rs
+          cargo docs
           rm -f target/doc/.lock
           cp -r target/doc/ docs/.vitepress/dist/rustdoc/
 

--- a/docs/src/contribute/documentation.md
+++ b/docs/src/contribute/documentation.md
@@ -24,7 +24,7 @@ Note that if you are only modifying the documentation contents without touching 
 The Deskulpt backend is documented with [rustdoc](https://doc.rust-lang.org/rustdoc/) for developers' internal reference. Unlike the public docs hosted on [docs.rs](https://docs.rs/), the internal rustdoc includes private crate items and is meant specifically to be used by Deskulpt developers. It is built separately from the main documentation website and hosted under its `rustdoc/` subdirectory. To build the internal backend rustdoc locally, run the following command:
 
 ```bash
-pnpm docs:rs
+cargo docs
 ```
 
 This command will print the path to the generated documentation, which you can open directly in our browser.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "preinstall": "npx only-allow pnpm",
     "prepare": "husky",
-    "tauri": "tauri",
     "format": "pnpm format:js && pnpm format:rs",
     "format:check": "pnpm format:js:check && pnpm format:rs:check",
     "format:js": "prettier --write .",
@@ -24,7 +23,6 @@
     "docs:dev": "pnpm --filter @deskulpt/docs dev",
     "docs:build": "pnpm --filter @deskulpt/docs build",
     "docs:preview": "pnpm --filter @deskulpt/docs preview",
-    "docs:rs": "cargo doc --workspace --no-deps --exclude xtask-gen",
     "build:packages": "pnpm run --sequential --filter @deskulpt-test/* build"
   },
   "devDependencies": {


### PR DESCRIPTION
- `cargo docs` instead of `pnpm docs:rs`
- The `"tauri": "tauri"` script is not necessary
- A comment for the "Check build" CI