### PR TITLE
feat!: make widgets resizable from canvas

### DIFF
--- a/crates/deskulpt-core/src/settings/mod.rs
+++ b/crates/deskulpt-core/src/settings/mod.rs
@@ -10,7 +10,7 @@ mod persistence;
 mod shortcuts;
 
 /// Light/dark theme of the application.
-#[derive(Clone, Default, Deserialize, Serialize, JsonSchema, specta::Type)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema, specta::Type)]
 #[serde(rename_all = "camelCase")]
 pub enum Theme {
     #[default]
@@ -20,7 +20,7 @@ pub enum Theme {
 
 /// Types of keyboard shortcuts in the application.
 #[derive(
-    Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize, JsonSchema, specta::Type,
+    Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize, JsonSchema, specta::Type,
 )]
 #[serde(rename_all = "camelCase")]
 pub enum ShortcutKey {
@@ -32,7 +32,7 @@ pub enum ShortcutKey {
 
 /// Application-wide settings.
 #[serde_as]
-#[derive(Clone, Default, Deserialize, Serialize, JsonSchema, specta::Type)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema, specta::Type)]
 #[serde(rename_all = "camelCase", default)]
 pub struct AppSettings {
     /// The application theme.
@@ -48,7 +48,7 @@ pub struct AppSettings {
 /// Different from widget configurations, these are independent of the widget
 /// configuration files and are managed internally by the application.
 #[serde_as]
-#[derive(Clone, Deserialize, Serialize, JsonSchema, specta::Type)]
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, specta::Type)]
 #[serde(rename_all = "camelCase", default)]
 pub struct WidgetSettings {
     /// The leftmost x-coordinate in pixels.
@@ -57,6 +57,12 @@ pub struct WidgetSettings {
     /// The topmost y-coordinate in pixels.
     #[serde_as(deserialize_as = "DefaultOnError")]
     pub y: i32,
+    /// The width in pixels.
+    #[serde_as(deserialize_as = "DefaultOnError")]
+    pub width: u32,
+    /// The height in pixels.
+    #[serde_as(deserialize_as = "DefaultOnError")]
+    pub height: u32,
     /// The opacity in percentage.
     #[serde(deserialize_with = "WidgetSettings::deserialize_opacity")]
     #[schemars(range(min = 1, max = 100))]
@@ -68,6 +74,8 @@ impl Default for WidgetSettings {
         Self {
             x: 0,
             y: 0,
+            width: 300,
+            height: 200,
             opacity: 100,
         }
     }
@@ -91,7 +99,7 @@ impl WidgetSettings {
 
 /// Full settings of the Deskulpt application.
 #[serde_as]
-#[derive(Clone, Default, Deserialize, Serialize, JsonSchema, specta::Type)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema, specta::Type)]
 #[serde(rename_all = "camelCase", default)]
 pub struct Settings {
     /// Application-wide settings.

--- a/docs/src/public/settings-schema.json
+++ b/docs/src/public/settings-schema.json
@@ -65,6 +65,20 @@
           "format": "int32",
           "default": 0
         },
+        "width": {
+          "description": "The width in pixels.",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0,
+          "default": 300
+        },
+        "height": {
+          "description": "The height in pixels.",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0,
+          "default": 200
+        },
         "opacity": {
           "description": "The opacity in percentage.",
           "type": "integer",

--- a/packages/deskulpt/package.json
+++ b/packages/deskulpt/package.json
@@ -14,6 +14,7 @@
     "@tauri-apps/api": "catalog:",
     "@tauri-apps/plugin-clipboard-manager": "catalog:",
     "@tauri-apps/plugin-opener": "catalog:",
+    "re-resizable": "catalog:",
     "react": "catalog:",
     "react-dom": "catalog:",
     "react-draggable": "catalog:",

--- a/packages/deskulpt/src/bindings.ts
+++ b/packages/deskulpt/src/bindings.ts
@@ -216,6 +216,14 @@ x: number;
  */
 y: number; 
 /**
+ * The width in pixels.
+ */
+width: number; 
+/**
+ * The height in pixels.
+ */
+height: number; 
+/**
  * The opacity in percentage.
  */
 opacity: number }

--- a/packages/deskulpt/src/canvas/hooks/useWidgetsStore.ts
+++ b/packages/deskulpt/src/canvas/hooks/useWidgetsStore.ts
@@ -3,20 +3,12 @@ import { WidgetSettings, events } from "../../bindings";
 import { FC, createElement } from "react";
 import ErrorDisplay from "../components/ErrorDisplay";
 
-interface WidgetProps {
+interface WidgetProps extends WidgetSettings {
   id: string;
-  x: number;
-  y: number;
-  opacity: number;
 }
 
-interface Widget {
-  Component: FC<WidgetProps>;
-  width?: string;
-  height?: string;
-}
-
-interface WidgetState extends Widget, WidgetSettings {
+interface WidgetState extends WidgetSettings {
+  component: FC<WidgetProps>;
   apisBlobUrl: string;
   moduleBlobUrl?: string;
 }
@@ -27,7 +19,7 @@ export const useWidgetsStore = create(() => ({
 
 export function updateWidgetRender(
   id: string,
-  widget: Widget,
+  component: FC<WidgetProps>,
   moduleBlobUrl: string,
   apisBlobUrl: string,
   settings?: WidgetSettings,
@@ -40,12 +32,9 @@ export function updateWidgetRender(
           ...state.widgets,
           [id]: {
             ...state.widgets[id],
-            // Not using spread syntax because undefined properties in the
-            // widget need to override their previous values as well
-            Component: widget.Component,
-            width: widget.width,
-            height: widget.height,
+            component,
             moduleBlobUrl,
+            apisBlobUrl,
           },
         },
       };
@@ -56,7 +45,7 @@ export function updateWidgetRender(
       return {
         widgets: {
           ...state.widgets,
-          [id]: { ...widget, ...settings, apisBlobUrl, moduleBlobUrl },
+          [id]: { ...settings, component, moduleBlobUrl, apisBlobUrl },
         },
       };
     }
@@ -80,11 +69,10 @@ export function updateWidgetRenderError(
           ...state.widgets,
           [id]: {
             ...state.widgets[id],
-            Component: () =>
+            component: () =>
               createElement(ErrorDisplay, { id, error, message }),
-            width: undefined,
-            height: undefined,
             moduleBlobUrl: undefined,
+            apisBlobUrl,
           },
         },
       };
@@ -97,12 +85,10 @@ export function updateWidgetRenderError(
           ...state.widgets,
           [id]: {
             ...settings,
-            Component: () =>
+            component: () =>
               createElement(ErrorDisplay, { id, error, message }),
-            apisBlobUrl,
-            width: undefined,
-            height: undefined,
             moduleBlobUrl: undefined,
+            apisBlobUrl,
           },
         },
       };

--- a/packages/deskulpt/src/manager/components/Widgets/Settings.tsx
+++ b/packages/deskulpt/src/manager/components/Widgets/Settings.tsx
@@ -48,6 +48,40 @@ const Y = ({ id }: SettingsProps) => {
   );
 };
 
+const Width = ({ id }: SettingsProps) => {
+  const width = useWidgetsStore((state) => state.widgets[id].settings.width);
+  const onValueChange = useCallback(
+    (value: number) => updateWidgetSettings(id, { width: value }, true),
+    [id],
+  );
+
+  return (
+    <IntegerInput
+      value={width}
+      min={0}
+      onValueChange={onValueChange}
+      width="60px"
+    />
+  );
+};
+
+const Height = ({ id }: SettingsProps) => {
+  const height = useWidgetsStore((state) => state.widgets[id].settings.height);
+  const onValueChange = useCallback(
+    (value: number) => updateWidgetSettings(id, { height: value }, true),
+    [id],
+  );
+
+  return (
+    <IntegerInput
+      value={height}
+      min={0}
+      onValueChange={onValueChange}
+      width="60px"
+    />
+  );
+};
+
 const Opacity = ({ id }: SettingsProps) => {
   const opacity = useWidgetsStore(
     (state) => state.widgets[id].settings.opacity,
@@ -60,7 +94,7 @@ const Opacity = ({ id }: SettingsProps) => {
   return (
     <IntegerInput
       value={opacity}
-      min={0}
+      min={1}
       max={100}
       onValueChange={onValueChange}
       width="60px"
@@ -87,6 +121,16 @@ const Settings = memo(({ id }: SettingsProps) => {
               <X id={id} />
               <LiaTimesSolid size={12} color="var(--gray-11)" />
               <Y id={id} />
+            </Flex>
+          </Table.Cell>
+        </Table.Row>
+        <Table.Row align="center">
+          <Table.RowHeaderCell>Size (px)</Table.RowHeaderCell>
+          <Table.Cell>
+            <Flex gap="1" align="center">
+              <Width id={id} />
+              <LiaTimesSolid size={12} color="var(--gray-11)" />
+              <Height id={id} />
             </Flex>
           </Table.Cell>
         </Table.Row>

--- a/packages/deskulpt/src/manager/hooks/useWidgetsStore.ts
+++ b/packages/deskulpt/src/manager/hooks/useWidgetsStore.ts
@@ -1,7 +1,13 @@
 import { create } from "zustand";
 import { WidgetConfig, WidgetSettings, commands, events } from "../../bindings";
 
-const DEFAULT_WIDGET_SETTINGS: WidgetSettings = { x: 0, y: 0, opacity: 100 };
+const DEFAULT_WIDGET_SETTINGS: WidgetSettings = {
+  x: 0,
+  y: 0,
+  width: 300,
+  height: 200,
+  opacity: 100,
+};
 
 interface WidgetState {
   config: WidgetConfig;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ catalogs:
     '@vitejs/plugin-react':
       specifier: ^5.0.4
       version: 5.0.4
+    re-resizable:
+      specifier: ^6.11.2
+      version: 6.11.2
     react:
       specifier: ^19.2.0
       version: 19.2.0
@@ -156,6 +159,9 @@ importers:
       '@tauri-apps/plugin-opener':
         specifier: 'catalog:'
         version: 2.5.0
+      re-resizable:
+        specifier: 'catalog:'
+        version: 6.11.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react:
         specifier: 'catalog:'
         version: 19.2.0
@@ -2657,6 +2663,12 @@ packages:
 
   randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
+
+  re-resizable@6.11.2:
+    resolution: {integrity: sha512-2xI2P3OHs5qw7K0Ud1aLILK6MQxW50TcO+DetD9eIV58j84TqYeHoZcL9H4GXFXXIh7afhH8mv5iUCXII7OW7A==}
+    peerDependencies:
+      react: ^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.13.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   react-dom@19.2.0:
     resolution: {integrity: sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==}
@@ -5408,6 +5420,11 @@ snapshots:
   randombytes@2.1.0:
     dependencies:
       safe-buffer: 5.2.1
+
+  re-resizable@6.11.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+    dependencies:
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
 
   react-dom@19.2.0(react@19.2.0):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,6 +16,7 @@ catalog:
   "@types/react": ^19.2.0
   "@types/react-dom": ^19.2.0
   "@vitejs/plugin-react": ^5.0.4
+  re-resizable: ^6.11.2
   react: ^19.2.0
   react-dom: ^19.2.0
   react-draggable: ^4.5.0


### PR DESCRIPTION
Towards #551.

- Widgets are now resizable from canvas.
- Widget entry should directly export the component, but not an object that also contains width and height.
- Additional width and height settings, also modifiable from manager (same as x and y).