### PR TITLE
chore: remove unnecessary AsRef<Path/str> generics

### DIFF
--- a/crates/deskulpt-common/src/init.rs
+++ b/crates/deskulpt-common/src/init.rs
@@ -1,3 +1,5 @@
+//! Common utilities for initializing internal Tauri plugins for Deskulpt.
+
 #[doc(hidden)]
 #[macro_export]
 macro_rules! __init_builder {
@@ -6,7 +8,7 @@ macro_rules! __init_builder {
     };
 }
 
-/// Initialize a [`tauri::plugin::Builder`].
+/// Initialize a `tauri::plugin::Builder`.
 ///
 /// The builder has its name automatically set to the crate name, and its
 /// invoke handler set to the commands specified in the build script. It can be

--- a/crates/deskulpt-core/src/config.rs
+++ b/crates/deskulpt-core/src/config.rs
@@ -95,9 +95,7 @@ impl WidgetConfig {
     ///
     /// This returns `None` if the directory is not considered a widget
     /// directory, or if the widget is explicitly marked as ignored.
-    pub fn load<P: AsRef<Path>>(dir: P) -> Option<Self> {
-        let dir = dir.as_ref();
-
+    pub fn load(dir: &Path) -> Option<Self> {
         let deskulpt_conf =
             match DeskulptConf::load(dir).context("Failed to load deskulpt.conf.json") {
                 Ok(Some(deskulpt_conf)) => deskulpt_conf,

--- a/crates/deskulpt-core/src/settings/persistence.rs
+++ b/crates/deskulpt-core/src/settings/persistence.rs
@@ -47,8 +47,8 @@ impl Settings {
     /// Corrupted settings file will attempt to recover as much data as
     /// possible, applying default values for the corrupted parts. However,
     /// if the file is completely corrupted, an error might still be returned.
-    pub fn load<P: AsRef<Path>>(persist_dir: P) -> Result<Self> {
-        let settings_path = persist_dir.as_ref().join(SETTINGS_FILE);
+    pub fn load(persist_dir: &Path) -> Result<Self> {
+        let settings_path = persist_dir.join(SETTINGS_FILE);
         if !settings_path.exists() {
             return Ok(Default::default());
         }
@@ -59,11 +59,10 @@ impl Settings {
     }
 
     /// Write the settings to the persistence directory.
-    pub fn dump<P: AsRef<Path>>(&self, persist_dir: P) -> Result<()> {
+    pub fn dump(&self, persist_dir: &Path) -> Result<()> {
         // On certain platforms, File::create fails if intermediate directories
         // do not exist, in which case we need to manually create the directory;
         // see https://doc.rust-lang.org/std/fs/struct.File.html#method.create
-        let persist_dir = persist_dir.as_ref();
         if !persist_dir.exists() {
             create_dir_all(persist_dir)?;
         }

--- a/crates/deskulpt-plugin-fs/src/commands/exists.rs
+++ b/crates/deskulpt-plugin-fs/src/commands/exists.rs
@@ -29,7 +29,7 @@ impl PluginCommand for Exists {
         engine: &EngineInterface,
         input: ExistsInputPayload,
     ) -> Result<bool> {
-        let path = engine.widget_dir(id)?.join(input.path);
+        let path = engine.widget_dir(&id)?.join(input.path);
         Ok(path.exists())
     }
 }

--- a/crates/deskulpt-plugin/src/interface.rs
+++ b/crates/deskulpt-plugin/src/interface.rs
@@ -33,7 +33,7 @@ impl EngineInterface {
     /// This method is a temporary implementation. The final implementation
     /// should use IPC to communicate with the Deskulpt core to get the widget
     /// directory.
-    pub fn widget_dir<S: AsRef<str>>(&self, id: S) -> Result<PathBuf> {
-        (self.widget_dir_fn)(id.as_ref())
+    pub fn widget_dir(&self, id: &str) -> Result<PathBuf> {
+        (self.widget_dir_fn)(id)
     }
 }


### PR DESCRIPTION
Very minor thing: an `&` or an `.as_ref()` is just fine in our cases, so there is no need to make generics. Also add/fix a few docs.