### PR TITLE
refactor: change command bindings to positional arguments

### DIFF
--- a/crates/xtask-gen/src/bindings.ts.hbs
+++ b/crates/xtask-gen/src/bindings.ts.hbs
@@ -49,11 +49,15 @@ export const commands = {
   {{@key}}: {
 {{#each this}}
 {{indent doc 4}}
-    {{this.key}}: ({{#if this.args}}payload: {
+    {{this.key}}: ({{#if this.args}}
 {{#each this.args}}
       {{this.name}}: {{this.ty}},
 {{/each}}
-    }{{/if}}) => invoke<{{this.ret_ty}}>("{{#if this.plugin_name}}plugin:{{this.plugin_name}}|{{this.name}}{{else}}{{this.name}}{{/if}}"{{#if this.args}}, payload{{/if}}),
+    {{/if}}) => invoke<{{this.ret_ty}}>("plugin:{{this.plugin_name}}|{{this.name}}"{{#if this.args}}, {
+{{#each this.args}}
+      {{this.name}},
+{{/each}}
+    }{{/if}}),
 {{#unless @last}}
 
 {{/unless}}

--- a/packages/deskulpt/src/bindings.ts
+++ b/packages/deskulpt/src/bindings.ts
@@ -273,9 +273,11 @@ export const commands = {
      * - Widget has a configuration error.
      * - Error bundling the widget.
      */
-    bundleWidget: (payload: {
+    bundleWidget: (
       id: string,
-    }) => invoke<string>("plugin:deskulpt-core|bundle_widget", payload),
+    ) => invoke<string>("plugin:deskulpt-core|bundle_widget", {
+      id,
+    }),
 
     /**
      * Call a plugin command (🚧 TODO 🚧).
@@ -291,12 +293,17 @@ export const commands = {
      * a temporary implementation), `app_handle` is using the default runtime but
      * it should be a generic `R: Runtime` parameter in the final implementation.
      */
-    callPlugin: (payload: {
+    callPlugin: (
       plugin: string,
       command: string,
       id: string,
       payload: JsonValue | null,
-    }) => invoke<JsonValue>("plugin:deskulpt-core|call_plugin", payload),
+    ) => invoke<JsonValue>("plugin:deskulpt-core|call_plugin", {
+      plugin,
+      command,
+      id,
+      payload,
+    }),
 
     /**
      * Wrapper of
@@ -306,9 +313,11 @@ export const commands = {
      * 
      * - Failed to emit the [`RenderWidgetsEvent`] to the canvas.
      */
-    emitOnRenderReady: (payload: {
+    emitOnRenderReady: (
       event: RenderWidgetsEvent,
-    }) => invoke<null>("plugin:deskulpt-core|emit_on_render_ready", payload),
+    ) => invoke<null>("plugin:deskulpt-core|emit_on_render_ready", {
+      event,
+    }),
 
     /**
      * Exit the application with cleanup.
@@ -317,9 +326,11 @@ export const commands = {
      * application in the end. Prior to exiting, it will try to dump the settings
      * for persistence, but failure to do so will not prevent exiting.
      */
-    exitApp: (payload: {
+    exitApp: (
       settings: Settings,
-    }) => invoke<void>("plugin:deskulpt-core|exit_app", payload),
+    ) => invoke<void>("plugin:deskulpt-core|exit_app", {
+      settings,
+    }),
 
     /**
      * Open the widgets directory or a specific widget directory.
@@ -333,9 +344,11 @@ export const commands = {
      * - Failed to access the widgets directory.
      * - Error opening the directory.
      */
-    openWidget: (payload: {
+    openWidget: (
       id: string | null,
-    }) => invoke<null>("plugin:deskulpt-core|open_widget", payload),
+    ) => invoke<null>("plugin:deskulpt-core|open_widget", {
+      id,
+    }),
 
     /**
      * Rescan the widgets directory and update the widget configuration map.
@@ -372,8 +385,10 @@ export const commands = {
      * 
      * - Failed to apply the side effects, if any.
      */
-    updateSettings: (payload: {
+    updateSettings: (
       update: SettingsUpdate,
-    }) => invoke<null>("plugin:deskulpt-core|update_settings", payload),
+    ) => invoke<null>("plugin:deskulpt-core|update_settings", {
+      update,
+    }),
   },
 };

--- a/packages/deskulpt/src/canvas/hooks/useRenderWidgetsListener.tsx
+++ b/packages/deskulpt/src/canvas/hooks/useRenderWidgetsListener.tsx
@@ -40,7 +40,7 @@ export function useRenderWidgetsListener() {
 
         let code;
         try {
-          code = await commands.core.bundleWidget({ id });
+          code = await commands.core.bundleWidget(id);
         } catch (error) {
           updateWidgetRenderError(
             id,

--- a/packages/deskulpt/src/manager/components/Widgets/GlobalActions.tsx
+++ b/packages/deskulpt/src/manager/components/Widgets/GlobalActions.tsx
@@ -31,7 +31,7 @@ const GlobalActions = memo(({ length }: GlobalActionsProps) => {
   }, []);
 
   const openAction = useCallback(() => {
-    commands.core.openWidget({ id: null }).catch(console.error);
+    commands.core.openWidget(null).catch(console.error);
   }, []);
 
   return (

--- a/packages/deskulpt/src/manager/components/Widgets/Header.tsx
+++ b/packages/deskulpt/src/manager/components/Widgets/Header.tsx
@@ -19,7 +19,7 @@ const Header = memo(({ id }: HeaderProps) => {
   }, [id]);
 
   const openAction = useCallback(() => {
-    commands.core.openWidget({ id }).catch(console.error);
+    commands.core.openWidget(id).catch(console.error);
   }, [id]);
 
   return (

--- a/packages/deskulpt/src/manager/hooks/useAppSettingsStore.ts
+++ b/packages/deskulpt/src/manager/hooks/useAppSettingsStore.ts
@@ -14,9 +14,7 @@ export async function toggleTheme() {
 }
 
 export async function updateShortcut(key: ShortcutKey, shortcut?: string) {
-  await commands.core.updateSettings({
-    update: { shortcut: [key, shortcut ?? null] },
-  });
+  await commands.core.updateSettings({ shortcut: [key, shortcut ?? null] });
   useAppSettingsStore.setState((state) => ({
     shortcuts: { ...state.shortcuts, [key]: shortcut },
   }));

--- a/packages/deskulpt/src/manager/hooks/useExitAppListener.ts
+++ b/packages/deskulpt/src/manager/hooks/useExitAppListener.ts
@@ -14,7 +14,7 @@ export function useExitAppListener() {
           ),
         ),
       };
-      commands.core.exitApp({ settings }).catch(console.error);
+      commands.core.exitApp(settings).catch(console.error);
     });
 
     return () => {

--- a/packages/deskulpt/src/manager/hooks/useWidgetsStore.ts
+++ b/packages/deskulpt/src/manager/hooks/useWidgetsStore.ts
@@ -51,7 +51,7 @@ export async function rescan(initial: boolean = false) {
 
   const event = widgetsArray.map(([id, { settings }]) => ({ id, settings }));
   if (initial) {
-    await commands.core.emitOnRenderReady({ event });
+    await commands.core.emitOnRenderReady(event);
   } else {
     await events.renderWidgets.emitTo("canvas", event);
   }


### PR DESCRIPTION
Most of our commands have few arguments that are mostly non-null. This means that specifying named arguments for the command bindings would only add complexity, not reduce. Only in cases where we have a lot of possibly-null arguments would named arguments make things easier, but specta will treat them as null instead of undefined (which makes them still mandatory), and we can always just make a rust-side struct to wrap the arguments anyways.

One benefit of named arguments that still remains is its explicitness, i.e., it is impossible to mess up the order of the arguments. However as said, our current commands have very few arguments in most cases, and we can always make a rust-side struct to wrap the arguments anyways. Even better, if we one day decides to fork specta, we can improve the `specta::specta` attribute by allowing to specify "named" or "positional", but that's clearly out of scope of this PR.