### PR TITLE
chore: rename deskulpt organization to deskulpt-apps

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -64,6 +64,6 @@ jobs:
         uses: peaceiris/actions-gh-pages@v4
         with:
           deploy_key: ${{ secrets.GH_PAGES_DEPLOY_KEY }}
-          external_repository: CSCI-SHU-410-SE-Project/CSCI-SHU-410-SE-Project.github.io
+          external_repository: deskulpt-apps/deskulpt-apps.github.io
           publish_branch: main
           publish_dir: docs-dist

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors    = ["The Deskulpt Development Team"]
 edition    = "2021"
 homepage   = "https://csci-shu-410-se-project.github.io/"
 license    = "MIT"
-repository = "https://github.com/CSCI-SHU-410-SE-Project/Deskulpt"
+repository = "https://github.com/deskulpt-apps/Deskulpt"
 version    = "0.0.1"
 
 [workspace.dependencies]

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 <a href="https://csci-shu-410-se-project.github.io/">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/raw/main/packages/deskulpt/public/deskulpt-wide-dark.svg" />
-    <img alt="Deskulpt" src="https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/raw/main/packages/deskulpt/public/deskulpt-wide.svg" width="300px" />
+    <source media="(prefers-color-scheme: dark)" srcset="https://github.com/deskulpt-apps/Deskulpt/raw/main/packages/deskulpt/public/deskulpt-wide-dark.svg" />
+    <img alt="Deskulpt" src="https://github.com/deskulpt-apps/Deskulpt/raw/main/packages/deskulpt/public/deskulpt-wide.svg" width="300px" />
   </picture>
 </a>
 
@@ -11,7 +11,7 @@
 
 <br />
 
-[![release](https://img.shields.io/github/v/release/CSCI-SHU-410-SE-Project/Deskulpt)](https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/releases/latest) [![ci](https://img.shields.io/github/actions/workflow/status/CSCI-SHU-410-SE-Project/Deskulpt/ci.yaml?label=ci&logo=github)](https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/actions/workflows/ci.yaml) [![hompage](https://img.shields.io/badge/homepage-Deskulpt-blue.svg)](https://csci-shu-410-se-project.github.io/)
+[![release](https://img.shields.io/github/v/release/deskulpt-apps/Deskulpt)](https://github.com/deskulpt-apps/Deskulpt/releases/latest) [![ci](https://img.shields.io/github/actions/workflow/status/deskulpt-apps/Deskulpt/ci.yaml?label=ci&logo=github)](https://github.com/deskulpt-apps/Deskulpt/actions/workflows/ci.yaml) [![hompage](https://img.shields.io/badge/homepage-Deskulpt-blue.svg)](https://csci-shu-410-se-project.github.io/)
 
 </div>
 
@@ -47,7 +47,7 @@ Website: [https://csci-shu-410-se-project.github.io/](https://csci-shu-410-se-pr
 
 ## Download
 
-Download the latest release of Deskulpt [here](https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/releases). See [Quick Start](https://csci-shu-410-se-project.github.io/guide/quick-start.html) for more details.
+Download the latest release of Deskulpt [here](https://github.com/deskulpt-apps/Deskulpt/releases). See [Quick Start](https://csci-shu-410-se-project.github.io/guide/quick-start.html) for more details.
 
 ## Contributing
 

--- a/crates/deskulpt-build/src/lib.rs
+++ b/crates/deskulpt-build/src/lib.rs
@@ -1,7 +1,7 @@
 #![doc = include_str!("../README.md")]
 #![doc(
-    html_logo_url = "https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/raw/main/packages/deskulpt/public/deskulpt.svg",
-    html_favicon_url = "https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/raw/main/packages/deskulpt/public/deskulpt.svg"
+    html_logo_url = "https://github.com/deskulpt-apps/Deskulpt/raw/main/packages/deskulpt/public/deskulpt.svg",
+    html_favicon_url = "https://github.com/deskulpt-apps/Deskulpt/raw/main/packages/deskulpt/public/deskulpt.svg"
 )]
 
 use std::path::PathBuf;

--- a/crates/deskulpt-common/src/lib.rs
+++ b/crates/deskulpt-common/src/lib.rs
@@ -1,7 +1,7 @@
 #![doc = include_str!("../README.md")]
 #![doc(
-    html_logo_url = "https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/raw/main/packages/deskulpt/public/deskulpt.svg",
-    html_favicon_url = "https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/raw/main/packages/deskulpt/public/deskulpt.svg"
+    html_logo_url = "https://github.com/deskulpt-apps/Deskulpt/raw/main/packages/deskulpt/public/deskulpt.svg",
+    html_favicon_url = "https://github.com/deskulpt-apps/Deskulpt/raw/main/packages/deskulpt/public/deskulpt.svg"
 )]
 
 pub mod bindings;

--- a/crates/deskulpt-core/src/lib.rs
+++ b/crates/deskulpt-core/src/lib.rs
@@ -1,7 +1,7 @@
 #![doc = include_str!("../README.md")]
 #![doc(
-    html_logo_url = "https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/raw/main/packages/deskulpt/public/deskulpt.svg",
-    html_favicon_url = "https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/raw/main/packages/deskulpt/public/deskulpt.svg"
+    html_logo_url = "https://github.com/deskulpt-apps/Deskulpt/raw/main/packages/deskulpt/public/deskulpt.svg",
+    html_favicon_url = "https://github.com/deskulpt-apps/Deskulpt/raw/main/packages/deskulpt/public/deskulpt.svg"
 )]
 
 use tauri::plugin::TauriPlugin;

--- a/crates/deskulpt-macros/src/lib.rs
+++ b/crates/deskulpt-macros/src/lib.rs
@@ -1,7 +1,7 @@
 #![doc = include_str!("../README.md")]
 #![doc(
-    html_logo_url = "https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/raw/main/packages/deskulpt/public/deskulpt.svg",
-    html_favicon_url = "https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/raw/main/packages/deskulpt/public/deskulpt.svg"
+    html_logo_url = "https://github.com/deskulpt-apps/Deskulpt/raw/main/packages/deskulpt/public/deskulpt.svg",
+    html_favicon_url = "https://github.com/deskulpt-apps/Deskulpt/raw/main/packages/deskulpt/public/deskulpt.svg"
 )]
 
 mod event;

--- a/crates/deskulpt-plugin-fs/src/lib.rs
+++ b/crates/deskulpt-plugin-fs/src/lib.rs
@@ -1,7 +1,7 @@
 #![doc = include_str!("../README.md")]
 #![doc(
-    html_logo_url = "https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/raw/main/packages/deskulpt/public/deskulpt.svg",
-    html_favicon_url = "https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/raw/main/packages/deskulpt/public/deskulpt.svg"
+    html_logo_url = "https://github.com/deskulpt-apps/Deskulpt/raw/main/packages/deskulpt/public/deskulpt.svg",
+    html_favicon_url = "https://github.com/deskulpt-apps/Deskulpt/raw/main/packages/deskulpt/public/deskulpt.svg"
 )]
 
 mod commands;

--- a/crates/deskulpt-plugin-macros/src/lib.rs
+++ b/crates/deskulpt-plugin-macros/src/lib.rs
@@ -1,7 +1,7 @@
 #![doc = include_str!("../README.md")]
 #![doc(
-    html_logo_url = "https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/raw/main/packages/deskulpt/public/deskulpt.svg",
-    html_favicon_url = "https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/raw/main/packages/deskulpt/public/deskulpt.svg"
+    html_logo_url = "https://github.com/deskulpt-apps/Deskulpt/raw/main/packages/deskulpt/public/deskulpt.svg",
+    html_favicon_url = "https://github.com/deskulpt-apps/Deskulpt/raw/main/packages/deskulpt/public/deskulpt.svg"
 )]
 
 use proc_macro::TokenStream;

--- a/crates/deskulpt-plugin-sys/src/lib.rs
+++ b/crates/deskulpt-plugin-sys/src/lib.rs
@@ -1,7 +1,7 @@
 #![doc = include_str!("../README.md")]
 #![doc(
-    html_logo_url = "https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/raw/main/packages/deskulpt/public/deskulpt.svg",
-    html_favicon_url = "https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/raw/main/packages/deskulpt/public/deskulpt.svg"
+    html_logo_url = "https://github.com/deskulpt-apps/Deskulpt/raw/main/packages/deskulpt/public/deskulpt.svg",
+    html_favicon_url = "https://github.com/deskulpt-apps/Deskulpt/raw/main/packages/deskulpt/public/deskulpt.svg"
 )]
 
 mod commands;

--- a/crates/deskulpt-plugin/src/lib.rs
+++ b/crates/deskulpt-plugin/src/lib.rs
@@ -1,7 +1,7 @@
 #![doc = include_str!("../README.md")]
 #![doc(
-    html_logo_url = "https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/raw/main/packages/deskulpt/public/deskulpt.svg",
-    html_favicon_url = "https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/raw/main/packages/deskulpt/public/deskulpt.svg"
+    html_logo_url = "https://github.com/deskulpt-apps/Deskulpt/raw/main/packages/deskulpt/public/deskulpt.svg",
+    html_favicon_url = "https://github.com/deskulpt-apps/Deskulpt/raw/main/packages/deskulpt/public/deskulpt.svg"
 )]
 
 mod command;

--- a/crates/deskulpt-workspace/src/lib.rs
+++ b/crates/deskulpt-workspace/src/lib.rs
@@ -1,7 +1,7 @@
 #![doc = include_str!("../README.md")]
 #![doc(
-    html_logo_url = "https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/raw/main/packages/deskulpt/public/deskulpt.svg",
-    html_favicon_url = "https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/raw/main/packages/deskulpt/public/deskulpt.svg"
+    html_logo_url = "https://github.com/deskulpt-apps/Deskulpt/raw/main/packages/deskulpt/public/deskulpt.svg",
+    html_favicon_url = "https://github.com/deskulpt-apps/Deskulpt/raw/main/packages/deskulpt/public/deskulpt.svg"
 )]
 
 use std::path::PathBuf;

--- a/crates/deskulpt/src/lib.rs
+++ b/crates/deskulpt/src/lib.rs
@@ -1,7 +1,7 @@
 #![doc = include_str!("../README.md")]
 #![doc(
-    html_logo_url = "https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/raw/main/packages/deskulpt/public/deskulpt.svg",
-    html_favicon_url = "https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/raw/main/packages/deskulpt/public/deskulpt.svg"
+    html_logo_url = "https://github.com/deskulpt-apps/Deskulpt/raw/main/packages/deskulpt/public/deskulpt.svg",
+    html_favicon_url = "https://github.com/deskulpt-apps/Deskulpt/raw/main/packages/deskulpt/public/deskulpt.svg"
 )]
 
 use deskulpt_core::path::PathExt;

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -98,7 +98,7 @@ export default defineConfig({
     socialLinks: [
       {
         icon: "github",
-        link: "https://github.com/CSCI-SHU-410-SE-Project/Deskulpt",
+        link: "https://github.com/deskulpt-apps/Deskulpt",
       },
     ],
     footer: {

--- a/docs/src/contribute/overview.md
+++ b/docs/src/contribute/overview.md
@@ -4,15 +4,15 @@ Deskulpt welcomes all sorts of contributions, no matter how large or small!
 
 ## Open Development
 
-The Deskulpt project is hosted on GitHub: https://github.com/CSCI-SHU-410-SE-Project/Deskulpt. We are a community based on openness and friendly, didactic discussions. We aspire to value everyones' contributions, and we are committed to providing a safe and welcoming environment for all. Decision-making is based on technical merit and concensus. Please refer to our [Code of Conduct](https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/blob/main/.github/CODE_OF_CONDUCT.md) for more information.
+The Deskulpt project is hosted on GitHub: https://github.com/deskulpt-apps/Deskulpt. We are a community based on openness and friendly, didactic discussions. We aspire to value everyones' contributions, and we are committed to providing a safe and welcoming environment for all. Decision-making is based on technical merit and concensus. Please refer to our [Code of Conduct](https://github.com/deskulpt-apps/Deskulpt/blob/main/.github/CODE_OF_CONDUCT.md) for more information.
 
 ## Bug Reports
 
-Please report bugs to the [issue tracker](https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/issues) after you have searched for previous issues and found no results. Please be as descriptive as possible. If applicable, please include your environment, software versions, widget codes, etc. so that the issue can be more easily reproducible.
+Please report bugs to the [issue tracker](https://github.com/deskulpt-apps/Deskulpt/issues) after you have searched for previous issues and found no results. Please be as descriptive as possible. If applicable, please include your environment, software versions, widget codes, etc. so that the issue can be more easily reproducible.
 
 ## Feature Requests
 
-Before requesting new features, please make sure to look through the [issue tracker](https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/issues) as your request may already exist. If it does not, submit an issue with title prefixed with `[feat]`. Please be as descriptive as possible, including necessary illustrations if applicable.
+Before requesting new features, please make sure to look through the [issue tracker](https://github.com/deskulpt-apps/Deskulpt/issues) as your request may already exist. If it does not, submit an issue with title prefixed with `[feat]`. Please be as descriptive as possible, including necessary illustrations if applicable.
 
 ## Submitting Pull Requests
 

--- a/docs/src/guide/quick-start.md
+++ b/docs/src/guide/quick-start.md
@@ -8,7 +8,7 @@ Deskulpt is currently available on the following desktop platforms:
 - MacOS (Catalina 10.15 and later, Intel and Apple Silicon)
 - Linux (X11, tested on Ubuntu)
 
-You can download the latest release of Deskulpt from [Github Releases](https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/releases/latest).
+You can download the latest release of Deskulpt from [Github Releases](https://github.com/deskulpt-apps/Deskulpt/releases/latest).
 
 ## Install
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -15,7 +15,7 @@ hero:
       link: /guide/introduction
     - theme: alt
       text: Download
-      link: https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/releases/latest
+      link: https://github.com/deskulpt-apps/Deskulpt/releases/latest
 
 features:
   - title: Fast, Lightweight, Cross-Platform
@@ -32,5 +32,5 @@ features:
 :::warning 🚧 Alpha Software
 Deskulpt is currently in early development stage. Features may be incomplete or unstable and are subject to change.
 
-We welcome early users! If you try it out and have feedback or issues, please [open a GitHub issue](https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/issues/new) to share them with us.
+We welcome early users! If you try it out and have feedback or issues, please [open a GitHub issue](https://github.com/deskulpt-apps/Deskulpt/issues/new) to share them with us.
 :::

--- a/packages/apis/package.json
+++ b/packages/apis/package.json
@@ -14,12 +14,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/CSCI-SHU-410-SE-Project/Deskulpt.git"
+    "url": "git+https://github.com/deskulpt-apps/Deskulpt.git"
   },
   "author": "The Deskulpt Development Team",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/issues"
+    "url": "https://github.com/deskulpt-apps/Deskulpt/issues"
   },
   "homepage": "https://csci-shu-410-se-project.github.io/",
   "dependencies": {

--- a/packages/deskulpt/src/manager/components/About/index.tsx
+++ b/packages/deskulpt/src/manager/components/About/index.tsx
@@ -46,9 +46,9 @@ const AboutTab = memo(() => {
             <Table.Row align="center">
               <Table.RowHeaderCell>Repository</Table.RowHeaderCell>
               <Table.Cell>
-                <CopyLink href="https://github.com/CSCI-SHU-410-SE-Project/Deskulpt">
+                <CopyLink href="https://github.com/deskulpt-apps/Deskulpt">
                   <Flex align="center" gap="1">
-                    <FaGithub /> CSCI-SHU-410-SE-Project/Deskulpt
+                    <FaGithub /> deskulpt-apps/Deskulpt
                   </Flex>
                 </CopyLink>
               </Table.Cell>

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -15,12 +15,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/CSCI-SHU-410-SE-Project/Deskulpt.git"
+    "url": "git+https://github.com/deskulpt-apps/Deskulpt.git"
   },
   "author": "The Deskulpt Development Team",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/issues"
+    "url": "https://github.com/deskulpt-apps/Deskulpt/issues"
   },
   "homepage": "https://csci-shu-410-se-project.github.io/",
   "devDependencies": {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -15,12 +15,12 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/CSCI-SHU-410-SE-Project/Deskulpt.git"
+    "url": "git+https://github.com/deskulpt-apps/Deskulpt.git"
   },
   "author": "The Deskulpt Development Team",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/CSCI-SHU-410-SE-Project/Deskulpt/issues"
+    "url": "https://github.com/deskulpt-apps/Deskulpt/issues"
   },
   "homepage": "https://csci-shu-410-se-project.github.io/",
   "devDependencies": {


### PR DESCRIPTION
There is an organization named `deskulpt` already: https://github.com/deskulpt, so we had to use deskulpt-apps instead.