### PR TITLE
chore: remove taplo from recommended vscode extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,3 @@
 {
-  "recommendations": [
-    "tauri-apps.tauri-vscode",
-    "rust-lang.rust-analyzer",
-    "tamasfe.even-better-toml"
-  ]
+  "recommendations": ["tauri-apps.tauri-vscode", "rust-lang.rust-analyzer"]
 }


### PR DESCRIPTION
In #519 we have switched from taplo to prettier-toml-plugin (underlying it's still taplo though). Hence we should remove that vscode extension recommendation.