### PR TITLE
fix: make non-initial widget scanning work correctly

### DIFF
--- a/packages/deskulpt/src/manager/hooks/useWidgetsStore.ts
+++ b/packages/deskulpt/src/manager/hooks/useWidgetsStore.ts
@@ -13,7 +13,7 @@ export async function rescan(initial: boolean = false) {
       return [id, config] as const;
     });
   } else {
-    const currentWidgets = useWidgetsStore.getState().widgets;
+    const currentWidgets = useWidgetsStore.getState();
     widgetsArray = Object.entries(configs).map(([id, config]) => {
       return [id, config] as const;
     });


### PR DESCRIPTION
This fixes the bug introduces in #566. In particular, it changed the widgets store structure but forgot to update the changed line in this PR correspondingly. This caused rescan to fail except on initial render. From user's perspective, it's that when adding or removing widgets, clicking rescan does not have any effect (we have to reload the manager window). This PR should fix that problem.

@vivienhenz24 Can you please confirm that this fixes the problem correctly on your side as well? I believe that the strange behavior we saw in yesterday's class (have to right click reload) was due to this bug.