### PR TITLE
chore: set canvas window title

### DIFF
--- a/crates/deskulpt-core/src/window/mod.rs
+++ b/crates/deskulpt-core/src/window/mod.rs
@@ -49,6 +49,7 @@ pub trait WindowExt<R: Runtime>: Manager<R> + SettingsStateExt<R> {
             DeskulptWindow::Canvas,
             WebviewUrl::App("src/canvas/index.html".into()),
         )
+        .title("Deskulpt Canvas")
         .maximized(true)
         .transparent(true)
         .decorations(false)


### PR DESCRIPTION
Though the canvas window does not have the titlebar, the title does affect views such as Windows task manager:

<img width="1718" height="1143" alt="image" src="https://github.com/user-attachments/assets/23d9f4cc-4811-474d-a3f9-6a2fe89cffb4" />

If title not set, it would be "Tauri App" which is not good.