### PR TITLE
refactor: result-like serializable and specta-compatible outcome type

### DIFF
--- a/crates/deskulpt-common/src/lib.rs
+++ b/crates/deskulpt-common/src/lib.rs
@@ -7,4 +7,5 @@
 pub mod bindings;
 pub mod event;
 pub mod init;
+pub mod outcome;
 pub mod window;

--- a/crates/deskulpt-common/src/outcome.rs
+++ b/crates/deskulpt-common/src/outcome.rs
@@ -1,0 +1,12 @@
+use serde::{Deserialize, Serialize};
+
+/// A result-like binary outcome.
+///
+/// This represents the outcome of an operation that can either succeed with a
+/// value of type `T` or fail with an error message.
+#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
+#[serde(tag = "type", content = "content", rename_all = "camelCase")]
+pub enum Outcome<T> {
+    Ok(T),
+    Err(String),
+}

--- a/packages/deskulpt/src/bindings.ts
+++ b/packages/deskulpt/src/bindings.ts
@@ -23,6 +23,14 @@ export type DeskulptWindow =
 export type JsonValue = null | boolean | number | string | JsonValue[] | { [key in string]: JsonValue }
 
 /**
+ * A result-like binary outcome.
+ * 
+ * This represents the outcome of an operation that can either succeed with a
+ * value of type `T` or fail with an error message.
+ */
+export type Outcome<T> = { type: "ok"; content: T } | { type: "err"; content: string }
+
+/**
  * Event for removing widgets.
  * 
  * This event is emitted from the manager window to the canvas window when
@@ -139,20 +147,24 @@ export type UpdateSettingsEvent = Settings
  * This is a collection of all widgets discovered locally, mapped from their
  * widget IDs to their configurations.
  */
-export type WidgetCatalog = { [key in string]: WidgetConfig }
+export type WidgetCatalog = { [key in string]: Outcome<WidgetConfig> }
 
 /**
  * Full configuration of a Deskulpt widget.
  */
-export type WidgetConfig = 
+export type WidgetConfig = { 
 /**
- * Valid configuration of a widget.
+ * The name of the widget.
  */
-{ type: "ok"; name: string; entry: string; dependencies: { [key in string]: string } } | 
+name: string; 
 /**
- * Error information if a widget failed to load.
+ * The entry point of the widget.
  */
-{ type: "err"; error: string }
+entry: string; 
+/**
+ * The dependencies of the widget.
+ */
+dependencies: { [key in string]: string } }
 
 /**
  * Per-widget settings.

--- a/packages/deskulpt/src/manager/components/Widgets/Config.tsx
+++ b/packages/deskulpt/src/manager/components/Widgets/Config.tsx
@@ -28,16 +28,16 @@ const Config = memo(({ id }: ConfigProps) => {
             <Table.Body>
               <Table.Row align="center">
                 <Table.RowHeaderCell>Name</Table.RowHeaderCell>
-                <Table.Cell>{config.name}</Table.Cell>
+                <Table.Cell>{config.content.name}</Table.Cell>
               </Table.Row>
               <Table.Row align="center">
                 <Table.RowHeaderCell>Entry</Table.RowHeaderCell>
-                <Table.Cell>{config.entry}</Table.Cell>
+                <Table.Cell>{config.content.entry}</Table.Cell>
               </Table.Row>
               <Table.Row align="center">
                 <Table.RowHeaderCell>Dependencies</Table.RowHeaderCell>
                 <Table.Cell>
-                  <Dependencies dependencies={config.dependencies} />
+                  <Dependencies dependencies={config.content.dependencies} />
                 </Table.Cell>
               </Table.Row>
             </Table.Body>
@@ -46,7 +46,7 @@ const Config = memo(({ id }: ConfigProps) => {
           <Box pl="2" m="0" asChild>
             <pre>
               <Code size="2" variant="ghost">
-                {config?.error ?? "Widget not found."}
+                {config?.content ?? "Widget not found."}
               </Code>
             </pre>
           </Box>


### PR DESCRIPTION
The `Outcome` is intended to be used in cases where it needs to be sent between frontend and backend. For instance, `WidgetCatalog` is a map of config or errors. Also there are cases where a command needs to return a map or array of output or errors.