### PR TITLE
chore: gitignore .zed/* workspace settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ dist-ssr
 
 # Editor directories and files
 .vscode/*
+.zed/*
 !.vscode/extensions.json
 .idea
 .DS_Store


### PR DESCRIPTION
BTW, recommended `.vscode/settings.json`:

```json
{
  "rust-analyzer.procMacro.ignored": {
    "specta-macros": ["Type"]
  }
}
```

Recommended `.zed/settings.json`:

```json
{
  "lsp": {
    "rust-analyzer": {
      "initialization_options": {
        "procMacro": {
          "ignored": {
            "specta-macros": ["Type"]
          }
        }
      }
    }
  }
}
```