### PR TITLE
feat: set background color based on theme for the manager window

### DIFF
--- a/crates/deskulpt-core/src/settings/mod.rs
+++ b/crates/deskulpt-core/src/settings/mod.rs
@@ -18,19 +18,6 @@ pub enum Theme {
     Dark,
 }
 
-impl Theme {
-    /// Get the background color associated with the theme.
-    ///
-    /// According to https://www.radix-ui.com/colors, the "Slate 1" color in
-    /// dark and light mode respectively.
-    pub fn background_color(&self) -> (u8, u8, u8) {
-        match self {
-            Theme::Light => (252, 252, 253), // #FCFCFD
-            Theme::Dark => (17, 17, 19),     // #111113
-        }
-    }
-}
-
 /// Types of keyboard shortcuts in the application.
 #[derive(
     Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Deserialize, Serialize, JsonSchema, specta::Type,

--- a/crates/deskulpt-core/src/window/mod.rs
+++ b/crates/deskulpt-core/src/window/mod.rs
@@ -8,6 +8,7 @@ use tauri::{
     App, AppHandle, Manager, Runtime, WebviewUrl, WebviewWindowBuilder, Window, WindowEvent,
 };
 
+use crate::settings::Theme;
 use crate::states::SettingsStateExt;
 
 /// Extention trait for window-related operations.
@@ -19,13 +20,20 @@ pub trait WindowExt<R: Runtime>: Manager<R> + SettingsStateExt<R> {
     {
         let settings = self.get_settings();
         let init_js = ManagerInitJS::generate(&settings)?;
+
+        // https://www.radix-ui.com/colors: "Slate 1" colors
+        let background_color = match settings.theme {
+            Theme::Light => (252, 252, 253), // #FCFCFD
+            Theme::Dark => (17, 17, 19),     // #111113
+        };
+
         WebviewWindowBuilder::new(
             self,
             DeskulptWindow::Manager,
             WebviewUrl::App("src/manager/index.html".into()),
         )
         .title("Deskulpt Manager")
-        .background_color(settings.theme.background_color().into())
+        .background_color(background_color.into())
         .inner_size(800.0, 500.0)
         .center()
         .resizable(false)


### PR DESCRIPTION
On Windows, the initial load time of webview is really really slow. The following is a release build, and you can see that the background is white for a really long time on first load of the manager window:

https://github.com/user-attachments/assets/a790cfe7-c0e6-4dc3-bf43-6b795c6de3b9

This is really bad. While we cannot easily fix the first load time (it's pretty fast on macOS and Linux, so this is more of a problem with MSEdgeWebview2 rather than us), we can set the background to be consistent with the frontend theme background so at least visually users don't see a color change.
