### PR TITLE
chore: change identifier to com.deskulpt

### DIFF
--- a/crates/deskulpt/tauri.conf.json
+++ b/crates/deskulpt/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "productName": "Deskulpt",
   "version": "../../package.json",
-  "identifier": "com.deskulpt.app",
+  "identifier": "com.deskulpt",
   "build": {
     "beforeDevCommand": "pnpm vite dev",
     "beforeBuildCommand": "pnpm build",


### PR DESCRIPTION
`com.deskulpt.app` is not okay for macos, see: https://github.com/tauri-apps/tauri/issues/12674

We would try `com.deskulpt`. If it is not unique enough, we should see a problem when releasing. Then we can consider other alternatives like `io.github.deskulpt` or `com.deskulpt.deskulpt` or others.