### PR TITLE
chore: prepare v0.2.0 changelog and fix changelog generation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
+        with:
+          fetch-depth: 0 # Needed for changelog generation
 
       - uses: ./.github/actions/setup-rust
         with:
@@ -38,9 +40,11 @@ jobs:
       - name: Generate release notes
         id: release-notes
         shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "RELEASE_NOTES<<EOF" >> $GITHUB_OUTPUT
-          git-cliff --unreleased --tag ${{ github.ref_name }} >> $GITHUB_OUTPUT
+          git-cliff >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Build Deskulpt

--- a/cliff.toml
+++ b/cliff.toml
@@ -58,12 +58,12 @@ https://github.com/{{ remote.github.owner }}/{{ remote.github.repo }}/compare/{{
 {%- endfor -%}
 
 {%- if github.contributors | length != 0 -%}
-  ## ❤️ Contributors{% raw %}\n\n{% endraw -%}
+  ## Contributors{% raw %}\n\n{% endraw -%}
   This release was made possible by the following contributors:{% raw %}\n\n{% endraw -%}
   {%- for contributor in github.contributors -%}
     - @{{ contributor.username }}{% raw %}\n{% endraw -%}
   {%- endfor -%}
   {% raw %}\n{% endraw -%}
-  Thank you all for your contributions!{% raw %}\n{% endraw -%}
+  Thank you all for your contributions! ❤️{% raw %}\n{% endraw -%}
 {%- endif -%}
 """

--- a/docs/whatsnew/v0.2.0.md
+++ b/docs/whatsnew/v0.2.0.md
@@ -1,0 +1,6 @@
+# What's New in Deskulpt v0.2.0
+
+> [!WARNING]
+> This is an unreleased version of Deskulpt, and this file will be updated over time until the release is finalized. TODO: Remove this warning before final release.
+
+We are excited to announce the release of Deskulpt v0.2.0! You can download it from [GitHub Releases](https://github.com/deskulpt-apps/Deskulpt/releases/tag/v0.2.0). For an exhaustive list of changes, please refer to the "Full Changelog" section of the [release notes](https://github.com/deskulpt-apps/Deskulpt/releases/tag/v0.2.0).


### PR DESCRIPTION
- Without `fetch-depth: 0` it does not have full history
- Without `GITHUB_TOKEN` we might reach GitHub API limit
- The workflow is already triggered on tag, so no need for `--unreleased --tag xxx`
- Generate v0.2.0 what's new template