### PR TITLE
chore: force tsc non-incremental rebuild in pnpm:build

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "docs:dev": "pnpm --filter @deskulpt/docs dev",
     "docs:build": "pnpm --filter @deskulpt/docs build",
     "docs:preview": "pnpm --filter @deskulpt/docs preview",
-    "build": "tsc -b && vite build",
+    "build": "tsc -b -f && vite build",
     "build:packages": "pnpm run --sequential --filter @deskulpt-test/* build"
   },
   "dependencies": {

--- a/packages/deskulpt-bindings/tsconfig.json
+++ b/packages/deskulpt-bindings/tsconfig.json
@@ -3,7 +3,6 @@
   "include": ["src/"],
   "compilerOptions": {
     "composite": true,
-    "incremental": true,
     "tsBuildInfoFile": "node_modules/.cache/tsconfig.tsbuildinfo"
   }
 }

--- a/packages/deskulpt-canvas/tsconfig.json
+++ b/packages/deskulpt-canvas/tsconfig.json
@@ -3,7 +3,6 @@
   "include": ["src/", "../../vite-env.d.ts"],
   "compilerOptions": {
     "composite": true,
-    "incremental": true,
     "tsBuildInfoFile": "node_modules/.cache/tsconfig.tsbuildinfo"
   }
 }

--- a/packages/deskulpt-manager/tsconfig.json
+++ b/packages/deskulpt-manager/tsconfig.json
@@ -3,7 +3,6 @@
   "include": ["src/", "../../vite-env.d.ts"],
   "compilerOptions": {
     "composite": true,
-    "incremental": true,
     "tsBuildInfoFile": "node_modules/.cache/tsconfig.tsbuildinfo"
   }
 }

--- a/packages/deskulpt-utils/tsconfig.json
+++ b/packages/deskulpt-utils/tsconfig.json
@@ -3,7 +3,6 @@
   "include": ["src/"],
   "compilerOptions": {
     "composite": true,
-    "incremental": true,
     "tsBuildInfoFile": "node_modules/.cache/tsconfig.tsbuildinfo"
   }
 }


### PR DESCRIPTION
Fixes #616.

- We are not that big of a project. `tsc` does not take too long even with full rebuild.
- Rust compilation dominates build time.
- Dev mode doesn't even need to build.