### PR TITLE
chore: wrap catalog in arc to avoid unnecessary cloning

### DIFF
--- a/crates/deskulpt-core/src/commands/bundle_widgets.rs
+++ b/crates/deskulpt-core/src/commands/bundle_widgets.rs
@@ -32,19 +32,17 @@ pub async fn bundle_widgets<R: Runtime>(
 ) -> CmdResult<()> {
     let widgets_dir = app_handle.widgets_dir()?;
 
-    let widgets: Vec<_> = {
-        let catalog = app_handle.get_widget_catalog();
-        match ids {
-            Some(ids) => ids
-                .into_iter()
-                .filter_map(|id| catalog.0.get(&id).cloned().map(|config| (id, config)))
-                .collect(),
-            None => catalog
-                .0
-                .iter()
-                .map(|(id, config)| (id.clone(), config.clone()))
-                .collect(),
-        }
+    let catalog = app_handle.get_widget_catalog().clone();
+    let widgets: Vec<_> = match ids {
+        Some(ids) => ids
+            .into_iter()
+            .filter_map(|id| catalog.0.get(&id).map(|config| (id, config)))
+            .collect(),
+        None => catalog
+            .0
+            .iter()
+            .map(|(id, config)| (id.clone(), config))
+            .collect(),
     };
 
     if widgets.is_empty() {

--- a/crates/deskulpt-core/src/commands/rescan_widgets.rs
+++ b/crates/deskulpt-core/src/commands/rescan_widgets.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use deskulpt_common::event::Event;
 use tauri::{command, AppHandle, Runtime};
 
@@ -26,7 +28,7 @@ use crate::states::{SettingsStateExt, WidgetCatalogStateExt};
 #[command]
 #[specta::specta]
 pub async fn rescan_widgets<R: Runtime>(app_handle: AppHandle<R>) -> CmdResult<()> {
-    let catalog = WidgetCatalog::load(app_handle.widgets_dir()?)?;
+    let catalog = Arc::new(WidgetCatalog::load(app_handle.widgets_dir()?)?);
     *app_handle.get_widget_catalog_mut() = catalog.clone();
 
     {

--- a/crates/deskulpt-core/src/config.rs
+++ b/crates/deskulpt-core/src/config.rs
@@ -70,7 +70,7 @@ impl LoadManifest for PackageManifest {
 }
 
 /// Full configuration of a Deskulpt widget.
-#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
+#[derive(Debug, Serialize, Deserialize, specta::Type)]
 #[serde(rename_all = "camelCase")]
 pub struct WidgetConfig {
     /// The name of the widget.
@@ -112,7 +112,7 @@ impl WidgetConfig {
 /// This is a collection of all widgets discovered locally, mapped from their
 /// widget IDs to their configurations. Invalid widgets are also included with
 /// their error messages.
-#[derive(Debug, Default, Clone, Serialize, Deserialize, specta::Type)]
+#[derive(Debug, Default, Serialize, Deserialize, specta::Type)]
 pub struct WidgetCatalog(pub BTreeMap<String, Outcome<WidgetConfig>>);
 
 impl WidgetCatalog {

--- a/crates/deskulpt-core/src/events.rs
+++ b/crates/deskulpt-core/src/events.rs
@@ -1,6 +1,7 @@
 //! Deskulpt core events.
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use deskulpt_common::event::Event;
 use deskulpt_common::outcome::Outcome;
@@ -43,4 +44,4 @@ pub struct UpdateSettingsEvent(pub Settings);
 /// This event is emitted from the backend to all frontend windows whenever
 /// there is a change in the widget catalog.
 #[derive(Clone, Serialize, Deserialize, specta::Type, Event)]
-pub struct UpdateWidgetCatalogEvent(pub WidgetCatalog);
+pub struct UpdateWidgetCatalogEvent(pub Arc<WidgetCatalog>);

--- a/crates/deskulpt-core/src/states/widget_catalog.rs
+++ b/crates/deskulpt-core/src/states/widget_catalog.rs
@@ -1,6 +1,6 @@
 //! State management for the widget catalog.
 
-use std::sync::{RwLock, RwLockReadGuard, RwLockWriteGuard};
+use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 use tauri::{App, AppHandle, Manager, Runtime};
 
@@ -9,7 +9,7 @@ use crate::path::PathExt;
 
 /// Managed state for the widget catalog.
 #[derive(Default)]
-struct WidgetCatalogState(RwLock<WidgetCatalog>);
+struct WidgetCatalogState(RwLock<Arc<WidgetCatalog>>);
 
 /// Extension trait for operations on widget catalog state.
 pub trait WidgetCatalogStateExt<R: Runtime>: Manager<R> + PathExt<R> {
@@ -22,7 +22,7 @@ pub trait WidgetCatalogStateExt<R: Runtime>: Manager<R> + PathExt<R> {
     ///
     /// The returned reference is behind a lock guard, which should be dropped
     /// as soon as possible to minimize critical section.
-    fn get_widget_catalog(&self) -> RwLockReadGuard<'_, WidgetCatalog> {
+    fn get_widget_catalog(&self) -> RwLockReadGuard<'_, Arc<WidgetCatalog>> {
         let state = self.state::<WidgetCatalogState>().inner();
         state.0.read().unwrap()
     }
@@ -31,7 +31,7 @@ pub trait WidgetCatalogStateExt<R: Runtime>: Manager<R> + PathExt<R> {
     ///
     /// The returned reference is behind a lock guard, which should be dropped
     /// as soon as possible to minimize critical section.
-    fn get_widget_catalog_mut(&self) -> RwLockWriteGuard<'_, WidgetCatalog> {
+    fn get_widget_catalog_mut(&self) -> RwLockWriteGuard<'_, Arc<WidgetCatalog>> {
         let state = self.state::<WidgetCatalogState>().inner();
         state.0.write().unwrap()
     }


### PR DESCRIPTION
Using `Arc<WidgetCatalog>` can simplify code and avoid expensive cloning (especially when serializing the event). An alternative is to use borrow, but it makes code (espectially deserialization) complex, and I don't think it brings any substancial performance or semantic benefits compared with using an `Arc`.