### PR TITLE
chore: let events borrow rather than own data

### DIFF
--- a/crates/deskulpt-common/src/event.rs
+++ b/crates/deskulpt-common/src/event.rs
@@ -9,9 +9,9 @@ use crate::window::DeskulptWindow;
 /// Trait for Deskulpt events.
 ///
 /// This trait should be derived using the [`derive@Event`] macro.
-pub trait Event: specta::Type + Serialize {
+pub trait Event: Serialize {
     /// The name of the event.
-    const NAME: &str;
+    const NAME: &'static str;
 
     /// Emit the event to all target.
     fn emit<R, E>(&self, emitter: &E) -> Result<()>

--- a/crates/deskulpt-core/src/commands/update_settings.rs
+++ b/crates/deskulpt-core/src/commands/update_settings.rs
@@ -23,8 +23,8 @@ pub async fn update_settings<R: Runtime>(
 ) -> CmdResult<()> {
     app_handle.apply_settings_patch(patch)?;
 
-    let settings = app_handle.get_settings().clone();
-    UpdateSettingsEvent(settings).emit(&app_handle)?;
+    let settings = app_handle.get_settings();
+    UpdateSettingsEvent(&settings).emit(&app_handle)?;
 
     Ok(())
 }

--- a/crates/deskulpt-core/src/config.rs
+++ b/crates/deskulpt-core/src/config.rs
@@ -70,7 +70,7 @@ impl LoadManifest for PackageManifest {
 }
 
 /// Full configuration of a Deskulpt widget.
-#[derive(Debug, Clone, Serialize, Deserialize, specta::Type)]
+#[derive(Debug, Serialize, Deserialize, specta::Type)]
 #[serde(rename_all = "camelCase")]
 pub struct WidgetConfig {
     /// The name of the widget.
@@ -112,7 +112,7 @@ impl WidgetConfig {
 /// This is a collection of all widgets discovered locally, mapped from their
 /// widget IDs to their configurations. Invalid widgets are also included with
 /// their error messages.
-#[derive(Debug, Default, Clone, Serialize, Deserialize, specta::Type)]
+#[derive(Debug, Default, Serialize, Deserialize, specta::Type)]
 pub struct WidgetCatalog(pub BTreeMap<String, Outcome<WidgetConfig>>);
 
 impl WidgetCatalog {

--- a/crates/deskulpt-core/src/events.rs
+++ b/crates/deskulpt-core/src/events.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use deskulpt_common::event::Event;
 use deskulpt_common::outcome::Outcome;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 use crate::config::WidgetCatalog;
 use crate::settings::Settings;
@@ -14,14 +14,14 @@ use crate::settings::Settings;
 /// This event is emitted from the backend to the canvas window to instruct it
 /// to render the provided widgets. The event carries a mapping from widget IDs
 /// to their corresponding code strings.
-#[derive(Clone, Serialize, Deserialize, specta::Type, Event)]
-pub struct RenderWidgetsEvent(pub HashMap<String, Outcome<String>>);
+#[derive(Debug, Serialize, specta::Type, Event)]
+pub struct RenderWidgetsEvent<'a>(pub &'a HashMap<String, Outcome<String>>);
 
 /// Event for showing a toast notification.
 ///
 /// This event is emitted from the backend to the canvas window when a toast
 /// notification needs to be displayed.
-#[derive(Clone, Serialize, Deserialize, specta::Type, Event)]
+#[derive(Debug, Serialize, specta::Type, Event)]
 #[serde(tag = "type", content = "content", rename_all = "camelCase")]
 pub enum ShowToastEvent {
     /// Show a [success](https://sonner.emilkowal.ski/toast#success) toast.
@@ -35,12 +35,12 @@ pub enum ShowToastEvent {
 /// This event is emitted from the backend to all frontend windows whenever
 /// there is a change in the settings. Full settings are included to ensure
 /// that all windows see the most up-to-date version eventually.
-#[derive(Clone, Serialize, Deserialize, specta::Type, Event)]
-pub struct UpdateSettingsEvent(pub Settings);
+#[derive(Debug, Serialize, specta::Type, Event)]
+pub struct UpdateSettingsEvent<'a>(pub &'a Settings);
 
 /// Event for updating the widget catalog.
 ///
 /// This event is emitted from the backend to all frontend windows whenever
 /// there is a change in the widget catalog.
-#[derive(Clone, Serialize, Deserialize, specta::Type, Event)]
-pub struct UpdateWidgetCatalogEvent(pub WidgetCatalog);
+#[derive(Debug, Serialize, specta::Type, Event)]
+pub struct UpdateWidgetCatalogEvent<'a>(pub &'a WidgetCatalog);

--- a/crates/deskulpt-core/src/settings/mod.rs
+++ b/crates/deskulpt-core/src/settings/mod.rs
@@ -35,7 +35,7 @@ pub enum ShortcutKey {
 /// Different from widget configurations, these are independent of the widget
 /// configuration files and are managed internally by the application.
 #[serde_as]
-#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, specta::Type)]
+#[derive(Debug, Deserialize, Serialize, JsonSchema, specta::Type)]
 #[serde(rename_all = "camelCase", default)]
 pub struct WidgetSettings {
     /// The leftmost x-coordinate in pixels.
@@ -107,7 +107,7 @@ pub struct WidgetSettingsPatch {
 
 /// Full settings of the Deskulpt application.
 #[serde_as]
-#[derive(Debug, Clone, Default, Deserialize, Serialize, JsonSchema, specta::Type)]
+#[derive(Debug, Default, Deserialize, Serialize, JsonSchema, specta::Type)]
 #[serde(rename_all = "camelCase", default)]
 pub struct Settings {
     /// The application theme.

--- a/crates/deskulpt-macros/src/event.rs
+++ b/crates/deskulpt-macros/src/event.rs
@@ -37,7 +37,7 @@ pub fn proc_derive_event(input: TokenStream) -> TokenStream {
 
     let expanded = quote! {
         impl #impl_generics ::deskulpt_common::event::Event for #ident #ty_generics #where_clause {
-            const NAME: &str = concat!(env!("CARGO_PKG_NAME"), "://", #lit);
+            const NAME: &'static str = concat!(env!("CARGO_PKG_NAME"), "://", #lit);
         }
     };
     TokenStream::from(expanded)


### PR DESCRIPTION
This, I hope, is the correct fix rather than #622 (which is reverted in #623).

The core is to try to reduce cloning. Since events (especially our emit-only events) really only need to borrow data instead of owning them, we remove `Deserialize` and turn them into borrowed structures. Note that adding `Deserialize` (if we ever need in the future) is also simple, because we can use `Cow`.

Some other changes:

- Remove `Clone` from those expensive structures. This will prevent us from mistakenly cloning them to the largest extent.
- Use `&'static str` in the `Event` derive macro, otherwise for borrowed structs the lifetime can mess up.
- Remove a bunch of clones where the events are used. Notably, in `rescan_widgets`, the full catalog update is postponed to after settings are correctly updated (which means failure to update settings would lead to failure of updating the catalog). Also in `bundle_widgets`, the render event is no longer emitted for widgets with invalid configurations.