### PR TITLE
fix: remove the localhost:8097 script from manager

### DIFF
--- a/packages/deskulpt-manager/index.html
+++ b/packages/deskulpt-manager/index.html
@@ -5,7 +5,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/deskulpt.svg" />
     <title>Deskulpt Manager</title>
-    <script src="http://localhost:8097"></script>
   </head>
 
   <body style="overflow: hidden; margin: 0">


### PR DESCRIPTION
This was earlier used for debugging using react devtools. Should not appear in production.