### PR TITLE
ci: use nightly rustdoc for the unstable `rustdoc-map` feature

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,6 +1,5 @@
 [alias]
-docs = "doc --workspace --no-deps --exclude xtask-gen"
-gen  = "run --bin xtask-gen --"
+gen = "run --bin xtask-gen --"
 
 [env]
 WORKSPACE_DIR = { value = "", relative = true }
@@ -9,8 +8,4 @@ WORKSPACE_DIR = { value = "", relative = true }
 # https://github.com/rolldown/rolldown/blob/90102d7b7a74319d2838619f504d661fcb9fff73/.cargo/config.toml#L6-L7
 rustflags = ["--cfg", "tracing_unstable"]
 
-rustdocflags = [
-  "--document-private-items",
-  "--extend-css",
-  "crates/rustdoc.css",
-]
+rustdocflags = ["--document-private-items"]

--- a/.github/actions/setup-rust/action.yaml
+++ b/.github/actions/setup-rust/action.yaml
@@ -24,16 +24,16 @@ inputs:
     required: true
     default: ""
 
+  nightly-components:
+    description: Rust components to install from the nightly toolchain.
+    type: string
+    required: true
+    default: ""
+
   tools:
     description: Additional tools to install.
     type: string
     required: false
-
-  nightly-rustfmt:
-    description: Whether to install rustfmt from the nightly toolchain.
-    type: boolean
-    required: true
-    default: false
 
   cache-key:
     description: The cache key.
@@ -74,11 +74,11 @@ runs:
         save-if: ${{ inputs.save-cache == 'true' }}
         cache-bin: false
 
-    - name: Install nightly rustfmt
-      if: ${{ inputs.nightly-rustfmt }}
+    - name: Install nightly components
+      if: ${{ inputs.nightly-components }}
       shell: bash
       run: |
-        rustup toolchain install nightly --component rustfmt --profile minimal --no-self-update
+        rustup toolchain install nightly --component ${{ inputs.nightly-components }} --profile minimal --no-self-update
 
     - name: Install tools
       uses: taiki-e/install-action@v2

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,8 +58,8 @@ jobs:
         with:
           platform: ubuntu-latest
           cache-key: debug
+          nightly-components: rustfmt
           tools: cargo-shear
-          nightly-rustfmt: true
 
       - uses: ./.github/actions/setup-node
 

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -27,7 +27,7 @@ jobs:
         with:
           platform: ubuntu-latest
           cache-key: debug
-          components: rust-docs
+          nightly-components: rust-docs
 
       - uses: ./.github/actions/setup-node
 
@@ -36,7 +36,7 @@ jobs:
 
       - name: Build rustdoc
         run: |
-          cargo docs
+          pnpm docs:rs
           rm -f target/doc/.lock
           cp -r target/doc/ docs/.vitepress/dist/rustdoc/
 

--- a/crates/deskulpt-build/Cargo.toml
+++ b/crates/deskulpt-build/Cargo.toml
@@ -16,4 +16,4 @@ syn          = { workspace = true }
 tauri-plugin = { workspace = true, features = ["build"] }
 
 [package.metadata.docs.rs]
-rustdoc-args = ["--extend-css", "../rustdoc.css"]
+rustdoc-args = ["--document-private-items"]

--- a/crates/deskulpt-common/Cargo.toml
+++ b/crates/deskulpt-common/Cargo.toml
@@ -17,4 +17,4 @@ specta          = { workspace = true, features = ["function"] }
 tauri           = { workspace = true }
 
 [package.metadata.docs.rs]
-rustdoc-args = ["--extend-css", "../rustdoc.css"]
+rustdoc-args = ["--document-private-items"]

--- a/crates/deskulpt-core/Cargo.toml
+++ b/crates/deskulpt-core/Cargo.toml
@@ -47,4 +47,4 @@ objc2 = { workspace = true }
 deskulpt-build = { workspace = true }
 
 [package.metadata.docs.rs]
-rustdoc-args = ["--extend-css", "../rustdoc.css"]
+rustdoc-args = ["--document-private-items"]

--- a/crates/deskulpt-macros/Cargo.toml
+++ b/crates/deskulpt-macros/Cargo.toml
@@ -18,4 +18,4 @@ quote = { workspace = true }
 syn   = { workspace = true }
 
 [package.metadata.docs.rs]
-rustdoc-args = ["--extend-css", "../rustdoc.css"]
+rustdoc-args = ["--document-private-items"]

--- a/crates/deskulpt-plugin-fs/Cargo.toml
+++ b/crates/deskulpt-plugin-fs/Cargo.toml
@@ -15,4 +15,4 @@ deskulpt-plugin = { workspace = true }
 serde           = { workspace = true, features = ["derive"] }
 
 [package.metadata.docs.rs]
-rustdoc-args = ["--extend-css", "../rustdoc.css"]
+rustdoc-args = ["--document-private-items"]

--- a/crates/deskulpt-plugin-macros/Cargo.toml
+++ b/crates/deskulpt-plugin-macros/Cargo.toml
@@ -17,4 +17,4 @@ quote = { workspace = true }
 syn   = { workspace = true }
 
 [package.metadata.docs.rs]
-rustdoc-args = ["--extend-css", "../rustdoc.css"]
+rustdoc-args = ["--document-private-items"]

--- a/crates/deskulpt-plugin-sys/Cargo.toml
+++ b/crates/deskulpt-plugin-sys/Cargo.toml
@@ -16,4 +16,4 @@ serde           = { workspace = true, features = ["derive"] }
 sysinfo         = { workspace = true }
 
 [package.metadata.docs.rs]
-rustdoc-args = ["--extend-css", "../rustdoc.css"]
+rustdoc-args = ["--document-private-items"]

--- a/crates/deskulpt-plugin/Cargo.toml
+++ b/crates/deskulpt-plugin/Cargo.toml
@@ -18,7 +18,7 @@ serde_json             = { workspace = true }
 serde = { workspace = true }
 
 [package.metadata.docs.rs]
-rustdoc-args = ["--extend-css", "../rustdoc.css"]
+rustdoc-args = ["--document-private-items"]
 
 [package.metadata.cargo-shear]
 ignored = [

--- a/crates/deskulpt-widgets/Cargo.toml
+++ b/crates/deskulpt-widgets/Cargo.toml
@@ -29,4 +29,4 @@ tokio           = { workspace = true }
 deskulpt-build = { workspace = true }
 
 [package.metadata.docs.rs]
-rustdoc-args = ["--extend-css", "../rustdoc.css"]
+rustdoc-args = ["--document-private-items"]

--- a/crates/deskulpt-workspace/Cargo.toml
+++ b/crates/deskulpt-workspace/Cargo.toml
@@ -10,4 +10,4 @@ repository = { workspace = true }
 version    = { workspace = true }
 
 [package.metadata.docs.rs]
-rustdoc-args = ["--extend-css", "../rustdoc.css"]
+rustdoc-args = ["--document-private-items"]

--- a/crates/deskulpt/Cargo.toml
+++ b/crates/deskulpt/Cargo.toml
@@ -21,4 +21,4 @@ tauri-plugin-opener            = { workspace = true }
 tauri-build = { workspace = true, features = ["codegen"] }
 
 [package.metadata.docs.rs]
-rustdoc-args = ["--extend-css", "../rustdoc.css"]
+rustdoc-args = ["--document-private-items"]

--- a/docs/src/contribute/documentation.md
+++ b/docs/src/contribute/documentation.md
@@ -24,7 +24,8 @@ Note that if you are only modifying the documentation contents without touching 
 The Deskulpt backend is documented with [rustdoc](https://doc.rust-lang.org/rustdoc/) for developers' internal reference. Unlike the public docs hosted on [docs.rs](https://docs.rs/), the internal rustdoc includes private crate items and is meant specifically to be used by Deskulpt developers. It is built separately from the main documentation website and hosted under its `rustdoc/` subdirectory. To build the internal backend rustdoc locally, run the following command:
 
 ```bash
-cargo docs
+pnpm docs:rs
+pnpm docs:rs --open # automatically open in your default browser
 ```
 
 This command will print the path to the generated documentation, which you can open directly in our browser.

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "docs:dev": "pnpm --filter @deskulpt/docs dev",
     "docs:build": "pnpm --filter @deskulpt/docs build",
     "docs:preview": "pnpm --filter @deskulpt/docs preview",
+    "docs:rs": "cargo +nightly doc --workspace --no-deps --exclude xtask-gen -Z rustdoc-map",
     "build": "tsc -b && vite build",
     "build:packages": "pnpm run --sequential --filter @deskulpt-test/* build"
   },


### PR DESCRIPTION
Closes #666. Compared to the screenshot in the linked issue, now all items from Tauri are correctly linked:

<p>
<img width="800" alt="image" src="https://github.com/user-attachments/assets/3118b3f9-cfff-4aa0-aff1-c99a4bdef26d" />
</p>

Now the doc build command should be `pnpm docs:rs` (again) rather than `cargo docs` (because it seems we cannot add the `+nightly` flag from cargo alias, maybe I missed something).

As for the CI, now the boolean `nightly-rustfmt` option is replaced with a comma-separated string `nightly-components` option, so that we can specify `rust-docs` there.

Another minor change: the `--document-private-items` option is added to docs.rs metadata of each crate. Meanwhile, the `--extend-css` option is removed everywhere. The reason for the second change is that we cannot have the CSS file outside the crate for docs.rs builds so we have to either manually copy (which is tedious) or use soft links (which does not work well on Windows). And ideally the logo just should not change with filter CSS in that way, there is already ongoing discussion of replacing our current logo with a new one that looks good in both dark and light themes.