### PR TITLE
refactor: use the tauri `default_window_icon` api for code clarity

### DIFF
--- a/crates/deskulpt-core/src/tray.rs
+++ b/crates/deskulpt-core/src/tray.rs
@@ -2,7 +2,6 @@
 
 use anyhow::Result;
 use deskulpt_settings::SettingsExt;
-use tauri::image::Image;
 use tauri::menu::{MenuBuilder, MenuEvent, MenuItemBuilder};
 use tauri::tray::{MouseButton, MouseButtonState, TrayIcon, TrayIconBuilder, TrayIconEvent};
 use tauri::{App, AppHandle, Runtime};
@@ -13,7 +12,7 @@ use crate::window::WindowExt;
 /// Extention trait for system tray-related operations.
 pub trait TrayExt<R: Runtime>: CanvasImodeStateExt<R> {
     /// Create the system tray.
-    fn create_tray(&self, icon: Image) -> Result<()>
+    fn create_tray(&self) -> Result<()>
     where
         Self: Sized,
     {
@@ -31,8 +30,12 @@ pub trait TrayExt<R: Runtime>: CanvasImodeStateExt<R> {
             .build()?;
 
         // Build the system tray icon
+        let icon = self
+            .app_handle()
+            .default_window_icon()
+            .expect("No default window icon");
         TrayIconBuilder::with_id("tray")
-            .icon(icon)
+            .icon(icon.clone())
             .icon_as_template(true)
             .show_menu_on_left_click(false)
             .tooltip("Deskulpt")

--- a/crates/deskulpt/src/lib.rs
+++ b/crates/deskulpt/src/lib.rs
@@ -9,11 +9,7 @@ use deskulpt_core::shortcuts::ShortcutsExt;
 use deskulpt_core::states::LoggingStateExt;
 use deskulpt_core::tray::TrayExt;
 use deskulpt_core::window::WindowExt;
-use tauri::image::Image;
-use tauri::{Builder, generate_context, include_image};
-
-/// Image object for the Deskulpt icon.
-const DESKULPT_ICON: Image = include_image!("./icons/icon.png");
+use tauri::{Builder, generate_context};
 
 /// Entry point for the Deskulpt backend.
 pub fn run() {
@@ -33,7 +29,7 @@ pub fn run() {
             app.init_shortcuts();
             app.create_manager()?;
             app.create_canvas()?;
-            app.create_tray(DESKULPT_ICON)?;
+            app.create_tray()?;
 
             Ok(())
         })


### PR DESCRIPTION
Closed #670. As described in the title.