### PR TITLE
feat: resizing from top and/or left should move that edge instead of its opposite

### DIFF
--- a/packages/deskulpt-canvas/src/components/WidgetContainer.tsx
+++ b/packages/deskulpt-canvas/src/components/WidgetContainer.tsx
@@ -77,7 +77,7 @@ function computeResizedGeometry(
 
 const WidgetContainer = memo(({ id }: WidgetContainerProps) => {
   const draggableRef = useRef<HTMLDivElement>(null);
-  const resizeStartRef = useRef<WidgetGeometry>();
+  const resizeStartRef = useRef<WidgetGeometry>(null);
 
   // This non-null assertion is safe because the IDs are obtained from the keys
   // of the widgets store
@@ -128,7 +128,7 @@ const WidgetContainer = memo(({ id }: WidgetContainerProps) => {
   }, [geometry]);
 
   const onResize: ResizeCallback = useCallback((_, direction, __, delta) => {
-    if (resizeStartRef.current == undefined) {
+    if (resizeStartRef.current === null) {
       return;
     }
     const newGeometry = computeResizedGeometry(
@@ -146,7 +146,7 @@ const WidgetContainer = memo(({ id }: WidgetContainerProps) => {
 
   const onResizeStop: ResizeCallback = useCallback(
     (_, direction, __, delta) => {
-      if (resizeStartRef.current == undefined) {
+      if (resizeStartRef.current === null) {
         return;
       }
 


### PR DESCRIPTION
Closed #682.

The usages of `useRef` and `flushSync` references [react-rnd's implementation](https://github.com/bokuweb/react-rnd/blob/34ccbfa162775b305b0c84836c8082e8caee9500/src/index.tsx).

https://github.com/user-attachments/assets/d6277ba9-a4fd-4002-ac5b-1126a1fc56cd

