### PR TITLE
ci: release changelog should only include latest

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -44,7 +44,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           echo "RELEASE_NOTES<<EOF" >> $GITHUB_OUTPUT
-          git-cliff >> $GITHUB_OUTPUT
+          git-cliff --latest >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Build Deskulpt


### PR DESCRIPTION
Without this flag, it will produce full changelog starting from initial commit.