### PR TITLE
fix(deps): update tracing-appender 0.2.4 to prune old logs on startup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6561,9 +6561,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "2d15d90a0b5c19378952d479dc858407149d7bb45a14de0142f6c534b16fc647"
 dependencies = [
  "pin-project-lite",
  "tracing-attributes",
@@ -6572,21 +6572,21 @@ dependencies = [
 
 [[package]]
 name = "tracing-appender"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
 dependencies = [
  "crossbeam-channel",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "time",
  "tracing-subscriber",
 ]
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.28"
+version = "0.1.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6606,9 +6606,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c"
 dependencies = [
  "once_cell",
  "valuable",
@@ -6647,9 +6647,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.20"
+version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
 dependencies = [
  "nu-ansi-term",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,10 +43,10 @@ tauri-plugin-clipboard-manager = "2.3.2"
 tauri-plugin-global-shortcut   = "2.3.1"
 tauri-plugin-opener            = "2.5.2"
 tokio                          = "1.48.0"
-tracing                        = "0.1.40"
-tracing-appender               = "0.2.3"
+tracing                        = "0.1.43"
+tracing-appender               = "0.2.4"
 tracing-panic                  = "0.1.2"
-tracing-subscriber             = "0.3.20"
+tracing-subscriber             = "0.3.21"
 
 # Deskulpt crates
 deskulpt-build         = { version = "0.2.0", path = "crates/deskulpt-build" }


### PR DESCRIPTION
Closes https://github.com/deskulpt-apps/Deskulpt/issues/701.

Dependencies updated according to https://github.com/tokio-rs/tracing/issues/3413, but the one we actually need is `tracing-appender = "0.2.4"`.