### PR TITLE
ci: fix frontend build check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -123,7 +123,7 @@ jobs:
       # a plain `cargo build` is sufficient for CI verification
       - name: Check build
         run: |
-          pnpm --filter deskulpt build
+          pnpm build
           cargo build --bin deskulpt
 
       - name: Check tests


### PR DESCRIPTION
`pnpm --filter deskulpt build` was the old command. Can't imagine that our CI has not been checking the frontend build for a long time.