### PR TITLE
refactor: use only lucide icons (with simple-icons for brands)

### DIFF
--- a/packages/deskulpt-manager/src/components/About/index.tsx
+++ b/packages/deskulpt-manager/src/components/About/index.tsx
@@ -1,7 +1,7 @@
 import { Avatar, Box, Flex, Heading, Table } from "@radix-ui/themes";
 import CopyLink from "../CopyLink";
 import { memo } from "react";
-import { FaGithub } from "react-icons/fa";
+import { SiGithub } from "react-icons/si";
 import { css } from "@emotion/react";
 
 const styles = {
@@ -47,7 +47,7 @@ const AboutTab = memo(() => {
               <Table.Cell>
                 <CopyLink href="https://github.com/deskulpt-apps/Deskulpt">
                   <Flex align="center" gap="1">
-                    <FaGithub /> deskulpt-apps/Deskulpt
+                    <SiGithub /> deskulpt-apps/Deskulpt
                   </Flex>
                 </CopyLink>
               </Table.Cell>

--- a/packages/deskulpt-manager/src/components/CopyLink.tsx
+++ b/packages/deskulpt-manager/src/components/CopyLink.tsx
@@ -1,5 +1,5 @@
 import { Flex, FlexProps, IconButton, Link, LinkProps } from "@radix-ui/themes";
-import { RxCopy } from "react-icons/rx";
+import { LuCopy } from "react-icons/lu";
 import { writeText } from "@tauri-apps/plugin-clipboard-manager";
 import { toast } from "sonner";
 import { useCallback } from "react";
@@ -27,7 +27,7 @@ const CopyLink = ({ gap = "2", children, ...linkProps }: CopyLinkProps) => {
           title="Copy link"
           onClick={handleCopy}
         >
-          <RxCopy />
+          <LuCopy />
         </IconButton>
       )}
     </Flex>

--- a/packages/deskulpt-manager/src/components/Logs/Header.tsx
+++ b/packages/deskulpt-manager/src/components/Logs/Header.tsx
@@ -3,8 +3,7 @@ import { LOGGING_LEVELS, logger } from "@deskulpt/utils";
 import { css } from "@emotion/react";
 import { Button, Flex, Popover, Select, Text } from "@radix-ui/themes";
 import { Dispatch, SetStateAction, memo, useCallback } from "react";
-import { LuFolderOpen, LuRepeat } from "react-icons/lu";
-import { MdDeleteOutline } from "react-icons/md";
+import { LuFolderOpen, LuRepeat, LuTrash } from "react-icons/lu";
 import { toast } from "sonner";
 
 const styles = {
@@ -84,7 +83,7 @@ const Header = memo(({ minLevel, setMinLevel, refreshLogs }: HeaderProps) => {
         <Popover.Root>
           <Popover.Trigger>
             <Button size="1" variant="surface" color="ruby">
-              <MdDeleteOutline /> Clear
+              <LuTrash /> Clear
             </Button>
           </Popover.Trigger>
           <Popover.Content size="1" maxWidth="300px">

--- a/packages/deskulpt-manager/src/components/Settings/Shortcut.tsx
+++ b/packages/deskulpt-manager/src/components/Settings/Shortcut.tsx
@@ -13,8 +13,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { FaEdit } from "react-icons/fa";
-import { MdClear } from "react-icons/md";
+import { LuSquarePen, LuTrash } from "react-icons/lu";
 import { deskulptSettings } from "@deskulpt/bindings";
 import { useSettingsStore } from "../../hooks";
 import { toast } from "sonner";
@@ -138,7 +137,7 @@ const ShortcutAction = ({ action }: Props) => {
       <Popover.Root onOpenChange={handleOpenChange}>
         <Popover.Trigger>
           <Button size="1" variant="surface">
-            <FaEdit /> Edit
+            <LuSquarePen /> Edit
           </Button>
         </Popover.Trigger>
         <Popover.Content size="1" width="400px">
@@ -166,7 +165,7 @@ const ShortcutAction = ({ action }: Props) => {
                   disabled={value === ""}
                   onClick={clearAction}
                 >
-                  <MdClear size="15" />
+                  <LuTrash size={15} />
                 </IconButton>
               </TextField.Slot>
             </TextField.Root>

--- a/packages/deskulpt-manager/src/components/Settings/index.tsx
+++ b/packages/deskulpt-manager/src/components/Settings/index.tsx
@@ -1,6 +1,6 @@
 import { Box, Button, Flex, ScrollArea, Table } from "@radix-ui/themes";
 import { memo, useCallback } from "react";
-import { FaEdit } from "react-icons/fa";
+import { LuSquarePen } from "react-icons/lu";
 import CanvasImode from "./CanvasImode";
 import Shortcut from "./Shortcut";
 import SectionTable from "./SectionTable";
@@ -48,7 +48,7 @@ const Settings = memo(() => {
       </ScrollArea>
 
       <Button size="2" variant="soft" color="gray" onClick={openSettingsJson}>
-        <FaEdit /> Edit in settings.json
+        <LuSquarePen /> Edit in settings.json
       </Button>
     </Flex>
   );

--- a/packages/deskulpt-manager/src/components/ThemeToggler.tsx
+++ b/packages/deskulpt-manager/src/components/ThemeToggler.tsx
@@ -1,6 +1,6 @@
 import { Box, IconButton } from "@radix-ui/themes";
 import { deskulptSettings } from "@deskulpt/bindings";
-import { MdOutlineDarkMode, MdOutlineLightMode } from "react-icons/md";
+import { LuMoon, LuSun } from "react-icons/lu";
 import { useCallback } from "react";
 import { logger } from "@deskulpt/utils";
 
@@ -23,7 +23,7 @@ const ThemeToggler = ({ theme }: ThemeTogglerProps) => {
         size="1"
         onClick={toggleTheme}
       >
-        {theme === "light" ? <MdOutlineLightMode /> : <MdOutlineDarkMode />}
+        {theme === "light" ? <LuSun /> : <LuMoon />}
       </IconButton>
     </Box>
   );

--- a/packages/deskulpt-manager/src/components/Widgets/GlobalActions.tsx
+++ b/packages/deskulpt-manager/src/components/Widgets/GlobalActions.tsx
@@ -21,7 +21,7 @@ const GlobalActions = memo(() => {
         variant="ghost"
         onClick={refreshAction}
       >
-        <LuRepeat size="16" />
+        <LuRepeat size={16} />
       </IconButton>
       <IconButton
         title="Open widgets directory"

--- a/packages/deskulpt-manager/src/components/Widgets/Settings.tsx
+++ b/packages/deskulpt-manager/src/components/Widgets/Settings.tsx
@@ -1,5 +1,5 @@
 import { Flex, Table } from "@radix-ui/themes";
-import { LiaTimesSolid } from "react-icons/lia";
+import { LuX } from "react-icons/lu";
 import { useSettingsStore } from "../../hooks";
 import { memo, useCallback } from "react";
 import IntegerInput from "../IntegerInput";
@@ -129,7 +129,7 @@ const Settings = memo(({ id }: SettingsProps) => {
           <Table.Cell>
             <Flex gap="1" align="center">
               <X id={id} />
-              <LiaTimesSolid size={12} color="var(--gray-11)" />
+              <LuX size={12} color="var(--gray-11)" />
               <Y id={id} />
             </Flex>
           </Table.Cell>
@@ -139,7 +139,7 @@ const Settings = memo(({ id }: SettingsProps) => {
           <Table.Cell>
             <Flex gap="1" align="center">
               <Width id={id} />
-              <LiaTimesSolid size={12} color="var(--gray-11)" />
+              <LuX size={12} color="var(--gray-11)" />
               <Height id={id} />
             </Flex>
           </Table.Cell>


### PR DESCRIPTION
[Lucide](https://lucide.dev/icons/) are nowadays standards. In order that we don't mess things up, this PR changes all icon usage to Lucide (except that Lucide does not include brand logos, in which case we use [Simple Icons](https://simpleicons.org/) as Lucide recommends. The reason we are still using `react-icons` rather than switching to `lucide-react` is also here - we also need brands, and I don't think `simple-icons` has a react-specialized library. But we should always keep in mind (and some day document in proper places) that we only expect to see `react-icons/lu` and `react-icons/si` imports.