### PR TITLE
fix(ui): fix settings tab overflow in height

### DIFF
--- a/packages/deskulpt-manager/src/components/Settings/index.tsx
+++ b/packages/deskulpt-manager/src/components/Settings/index.tsx
@@ -13,7 +13,7 @@ const Settings = memo(() => {
   }, []);
 
   return (
-    <Flex direction="column" gap="4" px="1">
+    <Flex direction="column" gap="4" px="1" height="100%">
       <ScrollArea asChild>
         <Box height="380px">
           <Flex direction="column" gap="4">


### PR DESCRIPTION
fixes #747

before
<img width="797" height="499" alt="Screenshot 2025-12-19 at 23 27 23" src="https://github.com/user-attachments/assets/5ba174cf-4c53-40b9-a04d-02effd8b35d6" />

after

<img width="803" height="501" alt="Screenshot 2025-12-19 at 23 45 36" src="https://github.com/user-attachments/assets/4980bfc2-215b-4901-bee6-a4f3f9c6b61c" />
