### PR TITLE
ci: avoid overwriting index.html redirection in rustdoc

### DIFF
--- a/.github/workflows/rustdoc.yaml
+++ b/.github/workflows/rustdoc.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: Sync rustdoc
         shell: bash
         run: |
-          rsync -av --delete --exclude ".git" target/doc/ rustdoc-repo/
+          rsync -av --delete --exclude ".git" --exclude "index.html" target/doc/ rustdoc-repo/
           touch rustdoc-repo/.nojekyll
 
       - name: Commit and push


### PR DESCRIPTION
As described in the title. Rustdoc itself does not have the index.html, and we manually created that redirect entry in the destination repo, hence in auto deploy we must not overwrite it.