### PR TITLE
refactor: explicit `tracing::` in code instead of top-level import

### DIFF
--- a/crates/tauri-plugin-deskulpt-core/src/shortcuts.rs
+++ b/crates/tauri-plugin-deskulpt-core/src/shortcuts.rs
@@ -5,7 +5,6 @@ use tauri::{App, AppHandle, Manager, Runtime};
 use tauri_plugin_deskulpt_settings::SettingsExt;
 use tauri_plugin_deskulpt_settings::model::ShortcutAction;
 use tauri_plugin_global_shortcut::{GlobalShortcut, GlobalShortcutExt, ShortcutState};
-use tracing::error;
 
 use crate::states::CanvasImodeStateExt;
 use crate::window::WindowExt;
@@ -27,12 +26,12 @@ fn reregister_shortcut<R: Runtime>(
     let handler: fn(&AppHandle<R>) = match action {
         ShortcutAction::ToggleCanvasImode => |app_handle| {
             if let Err(e) = app_handle.toggle_canvas_imode() {
-                error!("Failed to toggle canvas interaction mode: {e}");
+                tracing::error!("Failed to toggle canvas interaction mode: {e}");
             }
         },
         ShortcutAction::OpenPortal => |app_handle| {
             if let Err(e) = app_handle.open_portal() {
-                error!("Failed to open Deskulpt portal: {e}");
+                tracing::error!("Failed to open Deskulpt portal: {e}");
             }
         },
     };
@@ -61,7 +60,9 @@ pub trait ShortcutsExt<R: Runtime>: Manager<R> + SettingsExt<R> + GlobalShortcut
             let settings = self.settings().read();
             for (action, shortcut) in &settings.shortcuts {
                 if let Err(e) = reregister_shortcut(gs, action, None, Some(shortcut)) {
-                    error!("Failed to register shortcut {shortcut:?} for {action:?}: {e:?}");
+                    tracing::error!(
+                        "Failed to register shortcut {shortcut:?} for {action:?}: {e:?}"
+                    );
                 }
             }
         }
@@ -70,7 +71,7 @@ pub trait ShortcutsExt<R: Runtime>: Manager<R> + SettingsExt<R> + GlobalShortcut
         self.settings().on_shortcut_change(move |action, old, new| {
             let gs = app_handle.global_shortcut();
             if let Err(e) = reregister_shortcut(gs, action, old, new) {
-                error!(
+                tracing::error!(
                     "Failed to re-register shortcut from {old:?} to {new:?} for {action:?}: {e:?}"
                 );
             }

--- a/crates/tauri-plugin-deskulpt-core/src/states/canvas_imode.rs
+++ b/crates/tauri-plugin-deskulpt-core/src/states/canvas_imode.rs
@@ -12,7 +12,6 @@ use tauri::{App, AppHandle, Manager, PhysicalPosition, Runtime, WebviewWindow};
 use tauri_plugin_deskulpt_settings::SettingsExt;
 use tauri_plugin_deskulpt_settings::model::{CanvasImode, SettingsPatch};
 use tauri_plugin_deskulpt_widgets::WidgetsExt;
-use tracing::error;
 
 use crate::events::ShowToastEvent;
 
@@ -83,7 +82,7 @@ pub trait CanvasImodeStateExt<R: Runtime>: Manager<R> + SettingsExt<R> {
 
         self.settings().on_canvas_imode_change(move |_, new| {
             if let Err(e) = on_new_canvas_imode(&canvas, new) {
-                error!("Failed to update canvas interaction mode: {}", e);
+                tracing::error!("Failed to update canvas interaction mode: {}", e);
             }
         });
 
@@ -153,7 +152,7 @@ fn on_new_canvas_imode<R: Runtime>(canvas: &WebviewWindow<R>, mode: &CanvasImode
     if let Err(e) = ShowToastEvent::Success(format!("Canvas interaction mode: {mode:?}"))
         .emit_to(canvas, DeskulptWindow::Canvas)
     {
-        error!("Failed to emit ShowToastEvent to canvas: {}", e);
+        tracing::error!("Failed to emit ShowToastEvent to canvas: {}", e);
     }
 
     Ok(())

--- a/crates/tauri-plugin-deskulpt-core/src/tray.rs
+++ b/crates/tauri-plugin-deskulpt-core/src/tray.rs
@@ -6,7 +6,6 @@ use tauri::tray::{MouseButton, MouseButtonState, TrayIcon, TrayIconBuilder, Tray
 use tauri::{App, AppHandle, Manager, Runtime};
 use tauri_plugin_deskulpt_settings::SettingsExt;
 use tauri_plugin_deskulpt_widgets::WidgetsExt;
-use tracing::error;
 
 use crate::window::WindowExt;
 
@@ -54,17 +53,17 @@ fn on_menu_event<R: Runtime>(app_handle: &AppHandle<R>, event: MenuEvent) {
     match event.id().as_ref() {
         "tray-open-portal" => {
             if let Err(e) = app_handle.open_portal() {
-                error!("Failed to open Deskulpt portal: {e}");
+                tracing::error!("Failed to open Deskulpt portal: {e}");
             }
         },
         "tray-exit" => {
             if let Err(e) = app_handle.settings().persist() {
-                error!("Failed to persist settings before exit: {e}");
+                tracing::error!("Failed to persist settings before exit: {e}");
                 app_handle.exit(1);
                 return;
             }
             if let Err(e) = app_handle.widgets().persist() {
-                error!("Failed to persist widgets before exit: {e}");
+                tracing::error!("Failed to persist widgets before exit: {e}");
                 app_handle.exit(1);
                 return;
             }
@@ -85,6 +84,6 @@ fn on_tray_icon_event<R: Runtime>(tray: &TrayIcon<R>, event: TrayIconEvent) {
         && button_state == MouseButtonState::Down
         && let Err(e) = tray.app_handle().open_portal()
     {
-        error!("Failed to open Deskulpt portal: {e}");
+        tracing::error!("Failed to open Deskulpt portal: {e}");
     }
 }

--- a/crates/tauri-plugin-deskulpt-logs/src/commands.rs
+++ b/crates/tauri-plugin-deskulpt-logs/src/commands.rs
@@ -4,7 +4,6 @@
 use deskulpt_common::SerResult;
 use serde::Deserialize;
 use tauri::{AppHandle, Runtime, WebviewWindow};
-use tracing::{debug, error, info, trace, warn};
 
 use crate::LogsExt;
 use crate::reader::{Cursor, Page};
@@ -54,18 +53,18 @@ pub async fn log<R: Runtime>(
 ) -> SerResult<()> {
     match window.label() {
         "canvas" => match level {
-            Level::Trace => trace!(target: "frontend::canvas", %meta, message),
-            Level::Debug => debug!(target: "frontend::canvas", %meta, message),
-            Level::Info => info!(target: "frontend::canvas", %meta, message),
-            Level::Warn => warn!(target: "frontend::canvas", %meta, message),
-            Level::Error => error!(target: "frontend::canvas", %meta, message),
+            Level::Trace => tracing::trace!(target: "frontend::canvas", %meta, message),
+            Level::Debug => tracing::debug!(target: "frontend::canvas", %meta, message),
+            Level::Info => tracing::info!(target: "frontend::canvas", %meta, message),
+            Level::Warn => tracing::warn!(target: "frontend::canvas", %meta, message),
+            Level::Error => tracing::error!(target: "frontend::canvas", %meta, message),
         },
         "portal" => match level {
-            Level::Trace => trace!(target: "frontend::portal", %meta, message),
-            Level::Debug => debug!(target: "frontend::portal", %meta, message),
-            Level::Info => info!(target: "frontend::portal", %meta, message),
-            Level::Warn => warn!(target: "frontend::portal", %meta, message),
-            Level::Error => error!(target: "frontend::portal", %meta, message),
+            Level::Trace => tracing::trace!(target: "frontend::portal", %meta, message),
+            Level::Debug => tracing::debug!(target: "frontend::portal", %meta, message),
+            Level::Info => tracing::info!(target: "frontend::portal", %meta, message),
+            Level::Warn => tracing::warn!(target: "frontend::portal", %meta, message),
+            Level::Error => tracing::error!(target: "frontend::portal", %meta, message),
         },
         _ => {},
     }

--- a/crates/tauri-plugin-deskulpt-settings/src/manager.rs
+++ b/crates/tauri-plugin-deskulpt-settings/src/manager.rs
@@ -6,7 +6,6 @@ use anyhow::{Result, anyhow, bail};
 use deskulpt_common::event::Event;
 use parking_lot::{RwLock, RwLockReadGuard};
 use tauri::{AppHandle, Manager, Runtime};
-use tracing::error;
 use url::Url;
 
 use crate::events::UpdateEvent;
@@ -69,7 +68,7 @@ impl<R: Runtime> SettingsManager<R> {
             .join("settings.json");
 
         let settings = Settings::load(&persist_path).unwrap_or_else(|e| {
-            error!("Failed to load settings: {e:?}");
+            tracing::error!("Failed to load settings: {e:?}");
             Default::default()
         });
 

--- a/crates/tauri-plugin-deskulpt-settings/src/worker.rs
+++ b/crates/tauri-plugin-deskulpt-settings/src/worker.rs
@@ -7,7 +7,6 @@ use anyhow::Result;
 use tauri::{AppHandle, Runtime};
 use tokio::sync::mpsc;
 use tokio::time::{Instant, Sleep};
-use tracing::error;
 
 use crate::SettingsExt;
 use crate::model::{CanvasImode, ShortcutAction, Theme};
@@ -87,7 +86,7 @@ impl<R: Runtime> Worker<R> {
     fn on_persist_deadline(&mut self) {
         self.persist_pending = false;
         if let Err(e) = self.app_handle.settings().persist() {
-            error!("Failed to persist settings: {e:?}");
+            tracing::error!("Failed to persist settings: {e:?}");
         }
     }
 

--- a/crates/tauri-plugin-deskulpt-widgets/src/manager.rs
+++ b/crates/tauri-plugin-deskulpt-widgets/src/manager.rs
@@ -9,7 +9,6 @@ use parking_lot::RwLock;
 use tauri::{AppHandle, Manager, Runtime};
 use tauri_plugin_deskulpt_settings::SettingsExt;
 use tauri_plugin_deskulpt_settings::model::SettingsPatch;
-use tracing::{debug, error, info};
 
 use crate::catalog::{WidgetCatalog, WidgetSettingsPatch};
 use crate::events::UpdateEvent;
@@ -57,7 +56,7 @@ impl<R: Runtime> WidgetsManager<R> {
         let persist_path = app_handle.path().app_local_data_dir()?.join("widgets.json");
         let mut persisted_catalog =
             PersistedWidgetCatalog::load(&persist_path).unwrap_or_else(|e| {
-                error!("Failed to load persisted widgets: {e:?}");
+                tracing::error!("Failed to load persisted widgets: {e:?}");
                 Default::default()
             });
         catalog.0.iter_mut().for_each(|(k, v)| {
@@ -262,7 +261,7 @@ impl<R: Runtime> WidgetsManager<R> {
                 .join(widget);
             let dst = self.dir.join(&widget_id);
             if dst.exists() {
-                debug!(%widget_id, "Starter widget already exists, skipping");
+                tracing::debug!(%widget_id, "Starter widget already exists, skipping");
                 continue;
             }
 
@@ -270,11 +269,11 @@ impl<R: Runtime> WidgetsManager<R> {
                 .with_context(|| format!("Failed to add starter widget {widget_id}"))
             {
                 Ok(_) => {
-                    info!(%widget_id, "Added starter widget");
+                    tracing::info!(%widget_id, "Added starter widget");
                 },
                 Err(e) => {
                     has_error = true;
-                    error!(
+                    tracing::error!(
                         error = ?e,
                         %widget_id,
                         src = %src.display(),

--- a/crates/tauri-plugin-deskulpt-widgets/src/persist.rs
+++ b/crates/tauri-plugin-deskulpt-widgets/src/persist.rs
@@ -10,7 +10,6 @@ use serde_with::{MapSkipError, serde_as};
 use tauri::{AppHandle, Runtime};
 use tokio::sync::mpsc;
 use tokio::time::{Duration, Instant, Sleep};
-use tracing::error;
 
 use crate::WidgetsExt;
 use crate::catalog::{WidgetCatalog, WidgetSettings};
@@ -135,7 +134,7 @@ impl<R: Runtime> PersistWorker<R> {
     fn on_deadline(&mut self) {
         self.pending = false;
         if let Err(e) = self.app_handle.widgets().persist() {
-            error!("Failed to persist widgets: {e:?}");
+            tracing::error!("Failed to persist widgets: {e:?}");
         }
     }
 

--- a/crates/tauri-plugin-deskulpt-widgets/src/render/worker.rs
+++ b/crates/tauri-plugin-deskulpt-widgets/src/render/worker.rs
@@ -5,7 +5,6 @@ use deskulpt_common::event::Event;
 use deskulpt_common::window::DeskulptWindow;
 use tauri::{AppHandle, Runtime};
 use tokio::sync::mpsc;
-use tracing::error;
 
 use crate::WidgetsExt;
 use crate::events::RenderEvent;
@@ -49,7 +48,7 @@ async fn render_worker<R: Runtime>(
                     report: &report,
                 };
                 if let Err(e) = event.emit_to(&app_handle, DeskulptWindow::Canvas) {
-                    error!("Failed to emit RenderEvent for widget {id}: {e:?}");
+                    tracing::error!("Failed to emit RenderEvent for widget {id}: {e:?}");
                 };
             },
         }


### PR DESCRIPTION
Especially `error!`, auto import cannot work very well because there are so many "error" (case-insensitive). We had better just do explicit `tracing::error!` and similar.